### PR TITLE
changes to support UTF16 and LFN

### DIFF
--- a/ff_dir.c
+++ b/ff_dir.c
@@ -640,7 +640,7 @@ BaseType_t xFound;
 
 #if( ffconfigUNICODE_UTF16_SUPPORT != 0 )
 	FF_T_WCHAR mytoken[ ffconfigMAX_FILENAME ];
-	FF_T_WCHAR *token;
+	FF_T_WCHAR *pcToken;
 #else
 	char mytoken[ ffconfigMAX_FILENAME ];
 	char *pcToken;

--- a/ff_string.c
+++ b/ff_string.c
@@ -51,7 +51,7 @@
  */
 
 #if( ffconfigUNICODE_UTF16_SUPPORT != 0 )
-	void FF_cstrntowcs( FF_T_WCHAR *wcsDest, const int8_t *szpSource, uint32_t ulLength )
+	void FF_cstrntowcs( FF_T_WCHAR *wcsDest, const char *szpSource, uint32_t ulLength )
 	{
 		while( ( *szpSource != '\0' )  && ( ulLength-- != 0 ) )
 		{
@@ -63,7 +63,7 @@
 /*-----------------------------------------------------------*/
 
 #if( ffconfigUNICODE_UTF16_SUPPORT != 0 )
-	void FF_cstrtowcs( FF_T_WCHAR *wcsDest, const int8_t *szpSource )
+	void FF_cstrtowcs( FF_T_WCHAR *wcsDest, const char *szpSource )
 	{
 		while( *szpSource != '\0' )
 		{
@@ -75,7 +75,7 @@
 /*-----------------------------------------------------------*/
 
 #if( ffconfigUNICODE_UTF16_SUPPORT != 0 )
-	void FF_wcstocstr( int8_t *szpDest, const FF_T_WCHAR *wcsSource )
+	void FF_wcstocstr( char *szpDest, const FF_T_WCHAR *wcsSource )
 	{
 		while( *wcsSource != '\0' )
 		{
@@ -87,7 +87,7 @@
 /*-----------------------------------------------------------*/
 
 #if( ffconfigUNICODE_UTF16_SUPPORT != 0 )
-	void FF_wcsntocstr( int8_t *szpDest, const FF_T_WCHAR *wcsSource, uint32_t ulLength )
+	void FF_wcsntocstr( char *szpDest, const FF_T_WCHAR *wcsSource, uint32_t ulLength )
 	{
 		while( ( *wcsSource != '\0' ) && ( ulLength-- != 0 ) )
 		{
@@ -610,7 +610,7 @@
 		}
 		else if( ulSize < 2 )
 		{
-			lReturn FF_ERR_UNICODE_DEST_TOO_SMALL | FF_UTF32CTOUTF16C;	/* Not enough UTF-16 units to record this character. */
+			lReturn = FF_ERR_UNICODE_DEST_TOO_SMALL | FF_UTF32CTOUTF16C;	/* Not enough UTF-16 units to record this character. */
 		}
 		else if( utf32char < 0x00200000 )
 		{

--- a/include/ff_headers.h
+++ b/include/ff_headers.h
@@ -40,6 +40,7 @@ extern "C" {
 #include "FreeRTOSFATConfig.h"
 #include "FreeRTOSFATConfigDefaults.h"
 #include "ff_error.h"
+#include "ff_string.h"
 #include "ff_ioman.h"
 #include "ff_fat.h"
 #include "ff_fatdef.h"
@@ -48,7 +49,6 @@ extern "C" {
 #include "ff_crc.h"
 #include "ff_file.h"
 #include "ff_dir.h"
-#include "ff_string.h"
 #include "ff_format.h"
 #include "ff_locking.h"
 


### PR DESCRIPTION
-> Changed the function declarations in ff_string.c to match the prototypes in ff_string.h
-> Variable name in ff_dir.c is updated to build for UTF16 support enabled.
-> moving the #include ff_string.h higher in ff_header.h as it is used by other included files before 