### PR TITLE
Changes to FF_Locking.c

### DIFF
--- a/ff_format.c
+++ b/ff_format.c
@@ -115,6 +115,9 @@
 
 #define RESV_COUNT					32
 
+#define MX_LBA_TO_MOVE_FAT			8192uL
+#define SIZE_512_MB					0x100000uL
+
 #ifdef ffconfigMIN_CLUSTERS_FAT32
 	#define MIN_CLUSTER_COUNT_FAT32		ffconfigMIN_CLUSTERS_FAT32
 #else
@@ -289,7 +292,9 @@ FF_IOManager_t *pxIOManager = pxDisk->pxIOManager;
 		}
 	}
 
-	if( ( ucFATType == FF_T_FAT32 ) && ( ulSectorCount >= 0x100000UL ) )	/* Larger than 0.5 GB */
+	if( ( ucFATType == FF_T_FAT32 ) &&
+		( ulSectorCount >= SIZE_512_MB ) &&
+		( pxMyPartition->ulStartLBA < MX_LBA_TO_MOVE_FAT ) )
 	{
 	uint32_t ulRemaining;
 		/*
@@ -298,7 +303,7 @@ FF_IOManager_t *pxIOManager = pxDisk->pxIOManager;
 		 * See e.g. here:
 		 * http://3gfp.com/wp/2014/07/formatting-sd-cards-for-speed-and-lifetime/
 		 */
-		ulFATReservedSectors = 8192 - ulHiddenSectors;
+		ulFATReservedSectors = MX_LBA_TO_MOVE_FAT - ulHiddenSectors;
 		ulNonDataSectors = ulFATReservedSectors + iFAT16RootSectors;
 
 		ulRemaining = (ulNonDataSectors + 2 * ulSectorsPerFAT) % 128;

--- a/ff_ioman.c
+++ b/ff_ioman.c
@@ -401,6 +401,7 @@ const FF_Buffer_t *pxLastBuffer = &( pxIOManager->pxBuffers[ pxIOManager->usCach
 
 			if( pxMatchingBuffer->usNumHandles == 0 )
 			{
+				/* Copy the read & write flags. */
 				pxMatchingBuffer->ucMode = ( ucMode & FF_MODE_RD_WR );
 				if( ( ucMode & FF_MODE_WRITE ) != 0 )
 				{
@@ -413,7 +414,8 @@ const FF_Buffer_t *pxLastBuffer = &( pxIOManager->pxBuffers[ pxIOManager->usCach
 				break;
 			}
 
-			pxMatchingBuffer = NULL;	/* Sector is already in use, keep yielding until its available! */
+			/* Sector is already in use in a different mode, keep yielding until its available! */
+			pxMatchingBuffer = NULL;
 		}
 		else
 		{

--- a/ff_locking.c
+++ b/ff_locking.c
@@ -152,15 +152,11 @@ void FF_LockDirectory( FF_IOManager_t *pxIOManager )
 	{
 		/* Called when a task want to make changes to a directory.
 		First it waits for the desired bit to come high. */
-		xEventGroupWaitBits( pxIOManager->xEventGroup,
+		xBits = xEventGroupWaitBits( pxIOManager->xEventGroup,
 			FF_DIR_LOCK_EVENT_BITS, /* uxBitsToWaitFor */
-			( EventBits_t )0,       /* xClearOnExit */
+			pdTRUE,                 /* xClearOnExit */
 			pdFALSE,                /* xWaitForAllBits n.a. */
 			pdMS_TO_TICKS( 10000UL ) );
-
-		/* The next operation will only succeed for 1 task at a time,
-		because it is an atomary test & set operation: */
-		xBits = xEventGroupClearBits( pxIOManager->xEventGroup, FF_DIR_LOCK_EVENT_BITS );
 
 		if( ( xBits & FF_DIR_LOCK_EVENT_BITS ) != 0 )
 		{
@@ -248,15 +244,11 @@ EventBits_t xBits;
 	{
 		/* Called when a task want to make changes to the FAT area.
 		First it waits for the desired bit to come high. */
-		xEventGroupWaitBits( pxIOManager->xEventGroup,
+		xBits = xEventGroupWaitBits( pxIOManager->xEventGroup,
 			FF_FAT_LOCK_EVENT_BITS, /* uxBitsToWaitFor */
-			( EventBits_t )0,       /* xClearOnExit */
+			pdTRUE,                 /* xClearOnExit */
 			pdFALSE,                /* xWaitForAllBits n.a. */
 			pdMS_TO_TICKS( 10000UL ) );
-
-		/* The next operation will only succeed for 1 task at a time,
-		because it is an atomary test & set operation: */
-		xBits = xEventGroupClearBits( pxIOManager->xEventGroup, FF_FAT_LOCK_EVENT_BITS );
 
 		if( ( xBits & FF_FAT_LOCK_EVENT_BITS ) != 0 )
 		{
@@ -296,7 +288,7 @@ BaseType_t xReturn;
 	to become available. */
 	xBits = xEventGroupWaitBits( pxIOManager->xEventGroup,
 		FF_BUF_LOCK_EVENT_BITS, /* uxBitsToWaitFor */
-		FF_BUF_LOCK_EVENT_BITS, /* xClearOnExit */
+		pdTRUE,                 /* xClearOnExit */
 		pdFALSE,                /* xWaitForAllBits n.a. */
 		pdMS_TO_TICKS( xWaitMS ) );
 	if( ( xBits & FF_BUF_LOCK_EVENT_BITS ) != 0 )
@@ -319,7 +311,7 @@ void FF_BufferProceed( FF_IOManager_t *pxIOManager )
 		/* Scheduler not yet active. */
 		return;
 	}
-	/* Wake-up all tasks that are waiting for a sector buffer to become available. */
+	/* Wake-up a task that is waiting for a sector buffer to become available. */
 	xEventGroupSetBits( pxIOManager->xEventGroup, FF_BUF_LOCK_EVENT_BITS );
 }
 /*-----------------------------------------------------------*/

--- a/portable/Zynq.2019.3/ff_sddisk.c
+++ b/portable/Zynq.2019.3/ff_sddisk.c
@@ -1,0 +1,979 @@
+/*
+ * FreeRTOS+FAT Labs Build 160919 (C) 2016 Real Time Engineers ltd.
+ * Authors include James Walmsley, Hein Tibosch and Richard Barry
+ *
+ *******************************************************************************
+ ***** NOTE ******* NOTE ******* NOTE ******* NOTE ******* NOTE ******* NOTE ***
+ ***                                                                         ***
+ ***                                                                         ***
+ ***   FREERTOS+FAT IS STILL IN THE LAB:                                     ***
+ ***                                                                         ***
+ ***   This product is functional and is already being used in commercial    ***
+ ***   products.  Be aware however that we are still refining its design,    ***
+ ***   the source code does not yet fully conform to the strict coding and   ***
+ ***   style standards mandated by Real Time Engineers ltd., and the         ***
+ ***   documentation and testing is not necessarily complete.                ***
+ ***                                                                         ***
+ ***   PLEASE REPORT EXPERIENCES USING THE SUPPORT RESOURCES FOUND ON THE    ***
+ ***   URL: http://www.FreeRTOS.org/contact  Active early adopters may, at   ***
+ ***   the sole discretion of Real Time Engineers Ltd., be offered versions  ***
+ ***   under a license other than that described below.                      ***
+ ***                                                                         ***
+ ***                                                                         ***
+ ***** NOTE ******* NOTE ******* NOTE ******* NOTE ******* NOTE ******* NOTE ***
+ *******************************************************************************
+ *
+ * FreeRTOS+FAT can be used under two different free open source licenses.  The
+ * license that applies is dependent on the processor on which FreeRTOS+FAT is
+ * executed, as follows:
+ *
+ * If FreeRTOS+FAT is executed on one of the processors listed under the Special
+ * License Arrangements heading of the FreeRTOS+FAT license information web
+ * page, then it can be used under the terms of the FreeRTOS Open Source
+ * License.  If FreeRTOS+FAT is used on any other processor, then it can be used
+ * under the terms of the GNU General Public License V2.  Links to the relevant
+ * licenses follow:
+ *
+ * The FreeRTOS+FAT License Information Page: http://www.FreeRTOS.org/fat_license
+ * The FreeRTOS Open Source License: http://www.FreeRTOS.org/license
+ * The GNU General Public License Version 2: http://www.FreeRTOS.org/gpl-2.0.txt
+ *
+ * FreeRTOS+FAT is distributed in the hope that it will be useful.  You cannot
+ * use FreeRTOS+FAT unless you agree that you use the software 'as is'.
+ * FreeRTOS+FAT is provided WITHOUT ANY WARRANTY; without even the implied
+ * warranties of NON-INFRINGEMENT, MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. Real Time Engineers Ltd. disclaims all conditions and terms, be they
+ * implied, expressed, or statutory.
+ *
+ * _HT_ : last change: make the driver ready to mount several partitions on the
+ * same drive.
+ *
+ */
+
+/* Standard includes. */
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdio.h>
+
+/* Xilinx library includes. */
+#include "xparameters.h"
+#include "xil_types.h"
+#include "xsdps.h"		/* SD device driver */
+#include "xsdps_info.h"	/* SD info */
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "semphr.h"
+#include "portmacro.h"
+
+/* FreeRTOS+FAT includes. */
+#include "ff_headers.h"
+#include "ff_sddisk.h"
+#include "ff_sys.h"
+
+#if( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 )
+	#include "xil_exception.h"
+	#include "xscugic_hw.h"
+#endif /* ffconfigSDIO_DRIVER_USES_INTERRUPT */
+
+#include "uncached_memory.h"
+
+#define sdSIGNATURE 0x41404342
+
+#ifndef ARRAY_SIZE
+	#define	ARRAY_SIZE(x)	(int) (sizeof(x)/sizeof(x)[0])
+#endif
+
+#define STA_NOINIT		0x01	/* Drive not initialized */
+#define STA_NODISK		0x02	/* No medium in the drive */
+#define STA_PROTECT		0x04	/* Write protected */
+
+#define SD_DEVICE_ID					XPAR_XSDPS_0_DEVICE_ID
+#define HIGH_SPEED_SUPPORT				0x01
+#define WIDTH_4_BIT_SUPPORT				0x4
+#define SD_CLK_12_MHZ					12000000
+#define SD_CLK_25_MHZ					25000000
+#define SD_CLK_26_MHZ					26000000
+#define SD_CLK_52_MHZ					52000000
+#define EXT_CSD_DEVICE_TYPE_BYTE		196
+#define EXT_CSD_4_BIT_WIDTH_BYTE		183
+#define EXT_CSD_HIGH_SPEED_BYTE			185
+#define EXT_CSD_DEVICE_TYPE_HIGH_SPEED	0x3
+
+#define HUNDRED_64_BIT			100ULL
+#define BYTES_PER_MB			( 1024ull * 1024ull )
+#define SECTORS_PER_MB			( BYTES_PER_MB / 512ull )
+
+#define XSDPS_INTR_NORMAL_ENABLE ( XSDPS_INTR_CC_MASK | XSDPS_INTR_TC_MASK | \
+	XSDPS_INTR_DMA_MASK | XSDPS_INTR_CARD_INSRT_MASK | XSDPS_INTR_CARD_REM_MASK | \
+	XSDPS_INTR_ERR_MASK )
+
+/* Two defines used to set or clear the interrupt */
+#define INTC_BASE_ADDR		XPAR_SCUGIC_CPU_BASEADDR
+#define INTC_DIST_BASE_ADDR	XPAR_SCUGIC_DIST_BASEADDR
+
+/* Interupt numbers for SDIO units 0 and 1: */
+#define SCUGIC_SDIO_0_INTR	0x38
+#define SCUGIC_SDIO_1_INTR	0x4F
+
+/* Define a timeout on data transfers for SDIO: */
+#define sdWAIT_INT_TIME_OUT_MS		5000UL
+
+/* Define a short timeout, used during card-detection only (CMD1): */
+#ifndef	sdQUICK_WAIT_INT_TIME_OUT_MS
+	#define sdQUICK_WAIT_INT_TIME_OUT_MS	1000UL
+#endif
+
+/* XSdPs xSDCardInstance; */
+static XSdPs *pxSDCardInstance = NULL;
+
+static int sd_disk_status = STA_NOINIT;	/* Disk status */
+const int drive_nr = 0;
+static SemaphoreHandle_t xPlusFATMutex;
+#if( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 )
+	/* Create a semaphore for each of the two memory-card slots. */
+	static SemaphoreHandle_t xSDSemaphores[ 2 ];
+#endif
+
+static int vSDMMC_Init( int iDriveNumber );
+static int vSDMMC_Status( int iDriveNumber );
+
+#if( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 )
+	static void vInstallInterrupt( void );
+#endif
+
+extern int prvFFErrorToErrno( FF_Error_t xError );
+
+typedef struct xCACHE_MEMORY_INFO
+{
+	/* Reserve 'uncached' memory for caching sectors, will be passed to the +FAT library. */
+	uint8_t pucCacheMemory[ 0x10000 ];
+	/* Reserve 'uncached' memory for i/o to the SD-card. */
+	uint8_t pucHelpMemory[ 0x40000 ];
+	XSdPs xSDCardInstance;
+}
+CacheMemoryInfo_t;
+
+struct xCACHE_STATS
+{
+	uint32_t xMemcpyReadCount;
+	uint32_t xMemcpyWriteCount;
+	uint32_t xPassReadCount;
+	uint32_t xPassWriteCount;
+	uint32_t xFailReadCount;
+	uint32_t xFailWriteCount;
+};
+
+struct xCACHE_STATS xCacheStats;
+CacheMemoryInfo_t *pxCacheMemories[ ffconfigMAX_PARTITIONS ] = { 0 };
+
+static const uint8_t *prvStoreSDCardData( BaseType_t xPartition, const uint8_t *pucBuffer, uint32_t ulByteCount );
+static uint8_t *prvReadSDCardData( BaseType_t xPartition, uint8_t *pucBuffer, uint32_t ulByteCount );
+static CacheMemoryInfo_t *pucGetSDIOCacheMemory( BaseType_t xPartition );
+
+#if( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 )
+	void XSdPs_IntrHandler(void *XSdPsPtr);
+#endif /* ffconfigSDIO_DRIVER_USES_INTERRUPT */
+
+static int32_t prvFFRead( uint8_t *pucBuffer, uint32_t ulSectorNumber, uint32_t ulSectorCount, FF_Disk_t *pxDisk )
+{
+int32_t lReturnCode;
+int iResult;
+uint8_t *pucReadBuffer;
+
+	if( ( pxDisk != NULL ) &&		/*_RB_ Could this be changed to an assert? */
+		( pxDisk->ulSignature == sdSIGNATURE ) &&
+		( pxDisk->xStatus.bIsInitialised != pdFALSE ) &&
+		( ulSectorNumber < pxDisk->ulNumberOfSectors ) &&
+		( pxDisk->ulNumberOfSectors - ulSectorNumber ) >= ulSectorCount )
+	{
+		iResult = vSDMMC_Status( drive_nr );
+		if( ( iResult & STA_NODISK ) != 0 )
+		{
+			lReturnCode = FF_ERR_DRIVER_NOMEDIUM | FF_ERRFLAG;
+			FF_PRINTF( "prvFFRead: NOMEDIUM\n" );
+		}
+		else if( ( iResult & STA_NOINIT ) != 0 )
+		{
+			lReturnCode = FF_ERR_IOMAN_OUT_OF_BOUNDS_READ | FF_ERRFLAG;
+			FF_PRINTF( "prvFFRead: NOINIT\n" );
+		}
+		else if( ulSectorCount == 0ul )
+		{
+			lReturnCode = 0;
+		}
+		else
+		{
+			/* Convert LBA to byte address if needed */
+			if( pxSDCardInstance->HCS == 0 )
+			{
+				ulSectorNumber *= XSDPS_BLK_SIZE_512_MASK;
+			}
+
+			pucReadBuffer = prvReadSDCardData( pxDisk->xStatus.bPartitionNumber, pucBuffer, 512UL * ulSectorCount );
+
+			if( ucIsCachedMemory( pucReadBuffer ) != pdFALSE )
+			{
+				xCacheStats.xFailReadCount++;
+			}
+
+			iResult  = XSdPs_ReadPolled( pxSDCardInstance, ulSectorNumber, ulSectorCount, pucReadBuffer );
+			if( pucBuffer != pucReadBuffer )
+			{
+				xCacheStats.xMemcpyReadCount++;
+				memcpy( pucBuffer, pucReadBuffer, 512 * ulSectorCount );
+			}
+			else
+			{
+				xCacheStats.xPassReadCount++;
+			}
+			if( iResult == XST_SUCCESS )
+			{
+				lReturnCode = 0l;
+			}
+			else
+			{
+				lReturnCode = FF_ERR_IOMAN_OUT_OF_BOUNDS_READ | FF_ERRFLAG;
+			}
+		}
+	}
+	else
+	{
+		memset( ( void *) pucBuffer, '\0', ulSectorCount * 512 );
+
+		if( pxDisk->xStatus.bIsInitialised != pdFALSE )
+		{
+			FF_PRINTF( "prvFFRead: warning: %lu + %lu > %lu\n", ulSectorNumber, ulSectorCount, pxDisk->ulNumberOfSectors );
+		}
+
+		lReturnCode = FF_ERR_IOMAN_OUT_OF_BOUNDS_READ | FF_ERRFLAG;
+	}
+
+	return lReturnCode;
+}
+/*-----------------------------------------------------------*/
+
+static int32_t prvFFWrite( uint8_t *pucBuffer, uint32_t ulSectorNumber, uint32_t ulSectorCount, FF_Disk_t *pxDisk )
+{
+int32_t lReturnCode;
+
+	if( ( pxDisk != NULL ) &&
+		( pxDisk->ulSignature == sdSIGNATURE ) &&
+		( pxDisk->xStatus.bIsInitialised != pdFALSE ) &&
+		( ulSectorNumber < pxDisk->ulNumberOfSectors ) &&
+		( ( pxDisk->ulNumberOfSectors - ulSectorNumber ) >= ulSectorCount ) )
+	{
+		int iResult;
+		iResult = vSDMMC_Status(drive_nr);
+
+		if( ( iResult & STA_NODISK ) != 0 )
+		{
+			lReturnCode = FF_ERR_DRIVER_NOMEDIUM | FF_ERRFLAG;
+			FF_PRINTF( "prvFFWrite: NOMEDIUM\n" );
+		}
+		else if( ( iResult & STA_NOINIT ) != 0 )
+		{
+			lReturnCode = FF_ERR_IOMAN_OUT_OF_BOUNDS_WRITE | FF_ERRFLAG;
+			FF_PRINTF( "prvFFWrite: NOINIT\n" );
+		}
+		else
+		{
+			if( ulSectorCount == 0ul )
+			{
+				lReturnCode = 0l;
+			}
+			else
+			{
+				/* Convert LBA to byte address if needed */
+				if ( pxSDCardInstance->HCS == 0 )
+				{
+					ulSectorNumber *= XSDPS_BLK_SIZE_512_MASK;
+				}
+
+				pucBuffer = ( uint8_t * )prvStoreSDCardData( pxDisk->xStatus.bPartitionNumber, pucBuffer, 512UL * ulSectorCount );
+
+				if( ucIsCachedMemory( pucBuffer ) != pdFALSE )
+				{
+					xCacheStats.xFailWriteCount++;
+				}
+
+				iResult = XSdPs_WritePolled( pxSDCardInstance, ulSectorNumber, ulSectorCount, pucBuffer );
+
+				if( iResult == XST_SUCCESS )
+				{
+					lReturnCode = 0;
+				}
+				else
+				{
+					FF_PRINTF( "prvFFWrite[%d]: at 0x%X count %ld : %d\n",
+						(int)drive_nr, (unsigned)ulSectorNumber, ulSectorCount, iResult );
+					lReturnCode = FF_ERR_IOMAN_OUT_OF_BOUNDS_WRITE | FF_ERRFLAG;
+				}
+			}
+		}
+	}
+	else
+	{
+		lReturnCode = FF_ERR_IOMAN_OUT_OF_BOUNDS_WRITE | FF_ERRFLAG;
+		if( pxDisk->xStatus.bIsInitialised )
+		{
+			FF_PRINTF( "prvFFWrite::read: warning: %lu + %lu > %lu\n",
+				ulSectorNumber, ulSectorCount, pxDisk->ulNumberOfSectors );
+		}
+	}
+
+	return lReturnCode;
+}
+/*-----------------------------------------------------------*/
+
+void FF_SDDiskFlush( FF_Disk_t *pxDisk )
+{
+	if( ( pxDisk != NULL ) &&
+		( pxDisk->xStatus.bIsInitialised != pdFALSE ) &&
+		( pxDisk->pxIOManager != NULL ) )
+	{
+		FF_FlushCache( pxDisk->pxIOManager );
+	}
+}
+/*-----------------------------------------------------------*/
+
+static const uint8_t *prvStoreSDCardData( BaseType_t xPartition, const uint8_t *pucBuffer, uint32_t ulByteCount )
+{
+const uint8_t *pucReturn;
+CacheMemoryInfo_t *pxCache = pxCacheMemories[ xPartition ];
+
+	if( ( ucIsCachedMemory( pucBuffer ) != pdFALSE ) &&
+		( pxCache != NULL ) &&
+		( ulByteCount <= sizeof( pxCache->pucHelpMemory ) ) )
+	{
+		memcpy( pxCache->pucHelpMemory, pucBuffer, ulByteCount );
+		pucReturn = pxCache->pucHelpMemory;
+		xCacheStats.xMemcpyWriteCount++;
+	}
+	else
+	{
+		pucReturn = pucBuffer;
+		xCacheStats.xPassWriteCount++;
+	}
+
+	return pucReturn;
+}
+/*-----------------------------------------------------------*/
+
+static uint8_t *prvReadSDCardData( BaseType_t xPartition, uint8_t *pucBuffer, uint32_t ulByteCount )
+{
+uint8_t *pucReturn;
+CacheMemoryInfo_t *pxCache = pxCacheMemories[ xPartition ];
+
+	if( ( ucIsCachedMemory( pucBuffer ) != pdFALSE ) &&
+		( pxCache != NULL ) &&
+		( ulByteCount <= sizeof( pxCache->pucHelpMemory ) ) )
+	{
+		pucReturn = pxCache->pucHelpMemory;
+	}
+	else
+	{
+		pucReturn = pucBuffer;
+	}
+
+	return pucReturn;
+}
+/*-----------------------------------------------------------*/
+
+static CacheMemoryInfo_t *pucGetSDIOCacheMemory( BaseType_t xPartition )
+{
+CacheMemoryInfo_t *xReturn;
+	if( ( xPartition < 0 ) || ( xPartition >= ffconfigMAX_PARTITIONS ) )
+	{
+		FF_PRINTF("pucGetSDIOCacheMemory: bad partition number: %d ( max %d )\n", xPartition, ffconfigMAX_PARTITIONS - 1 );
+		xReturn = NULL;
+	}
+	else if( pxCacheMemories[ xPartition ] == NULL )
+	{
+	size_t uxSize = sizeof( *pxCacheMemories[ xPartition ] );
+
+		pxCacheMemories[ xPartition ] = ( CacheMemoryInfo_t * ) pucGetUncachedMemory( uxSize );
+		if( pxCacheMemories[ xPartition ] != NULL )
+		{
+			memset( pxCacheMemories[ xPartition ], 0, uxSize );
+		}
+		xReturn = pxCacheMemories[ xPartition ];
+	}
+	else
+	{
+		xReturn = pxCacheMemories[ xPartition ];
+	}
+	return xReturn;
+}
+/*-----------------------------------------------------------*/
+
+/* Initialise the SDIO driver and mount an SD card */
+BaseType_t xMountFailIgnore = 0;
+
+/* _HT_ : the function FF_SDDiskInit() used to mount partition-0.
+ * It would be nice if it has a parameter indicating the partition
+ * number.
+ * As for now, the partion can be set with a global variable 'xDiskPartition'.
+ */
+BaseType_t xDiskPartition = 0;
+
+FF_Disk_t *FF_SDDiskInit( const char *pcName )
+{
+FF_Error_t xFFError;
+BaseType_t xPartitionNumber = xDiskPartition;
+FF_CreationParameters_t xParameters;
+FF_Disk_t * pxDisk = NULL;
+CacheMemoryInfo_t *pxCacheMem = NULL;
+#if( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 )
+	int iIndex;
+#endif
+
+	do
+	{
+		if( pucGetSDIOCacheMemory( xPartitionNumber ) == NULL )
+		{
+			FF_PRINTF( "FF_SDDiskInit: Cached memory failed\n" );
+			break;
+		}
+		pxCacheMem = pxCacheMemories[ xPartitionNumber ];
+		if( pxSDCardInstance == NULL )
+		{
+			pxSDCardInstance = &( pxCacheMem->xSDCardInstance );
+		}
+		#if( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 )
+		{
+			for( iIndex = 0; iIndex < ARRAY_SIZE( xSDSemaphores ); iIndex++ )
+			{
+				if( xSDSemaphores[ iIndex ] == NULL )
+				{
+					xSDSemaphores[ iIndex ] = xSemaphoreCreateBinary();
+					configASSERT( xSDSemaphores[ iIndex ] != NULL );
+				}
+			}
+		}
+		#endif
+		if ( sd_disk_status != XST_SUCCESS )
+		{
+			vSDMMC_Init( 0 );
+			if ( sd_disk_status != XST_SUCCESS )
+			{
+				FF_PRINTF( "FF_SDDiskInit: vSDMMC_Init failed with rc %d\n", sd_disk_status );
+				break;
+			}
+		}
+
+		pxDisk = ( FF_Disk_t * ) pvPortMalloc( sizeof( *pxDisk ) );
+		if( pxDisk == NULL )
+		{
+			FF_PRINTF( "FF_SDDiskInit: Malloc failed\n" );
+			break;
+		}
+
+		/* Initialise the created disk structure. */
+		memset( pxDisk, '\0', sizeof( *pxDisk ) );
+
+		pxDisk->ulNumberOfSectors = myCSD.sd_last_block_address + 1;
+
+		if( xPlusFATMutex == NULL )
+		{
+			xPlusFATMutex = xSemaphoreCreateRecursiveMutex();
+			if( xPlusFATMutex == NULL )
+			{
+				FF_PRINTF( "FF_SDDiskInit: Can not create xPlusFATMutex\n" );
+				FF_SDDiskDelete( pxDisk );
+				pxDisk = NULL;
+				break;
+			}
+		}
+		pxDisk->ulSignature = sdSIGNATURE;
+
+		memset( &xParameters, '\0', sizeof( xParameters ) );
+		xParameters.pucCacheMemory = pxCacheMem->pucCacheMemory;
+		xParameters.ulMemorySize = sizeof( pxCacheMem->pucCacheMemory );
+		xParameters.ulSectorSize = 512;
+		xParameters.fnWriteBlocks = prvFFWrite;
+		xParameters.fnReadBlocks = prvFFRead;
+		xParameters.pxDisk = pxDisk;
+
+		/* prvFFRead()/prvFFWrite() are not re-entrant and must be protected with
+		the use of a semaphore. */
+		xParameters.xBlockDeviceIsReentrant = pdFALSE;
+
+		/* The semaphore will be used to protect critical sections in the +FAT driver,
+		and also to avoid concurrent calls to prvFFRead()/prvFFWrite() from different tasks. */
+		xParameters.pvSemaphore = ( void * ) xPlusFATMutex;
+
+		pxDisk->pxIOManager = FF_CreateIOManger( &xParameters, &xFFError );
+		if( pxDisk->pxIOManager == NULL )
+		{
+			FF_PRINTF( "FF_SDDiskInit: FF_CreateIOManger: %s\n", (const char*)FF_GetErrMessage( xFFError ) );
+			FF_SDDiskDelete( pxDisk );
+			pxDisk = NULL;
+			break;
+		}
+		pxDisk->xStatus.bIsInitialised = pdTRUE;
+		pxDisk->xStatus.bPartitionNumber = xPartitionNumber;
+
+		if( FF_SDDiskMount( pxDisk ) == 0 )
+		{
+			/* _HT_ Suppose that the partition is not yet
+			formatted, it might be desireable to have a valid
+			i/o manager. */
+			if (xMountFailIgnore == 0) {
+				FF_SDDiskDelete( pxDisk );
+				pxDisk = NULL;
+			}
+		}
+		else
+		{
+			if( pcName == NULL )
+			{
+				pcName = "/";
+			}
+
+			FF_FS_Add( pcName, pxDisk );
+			FF_PRINTF( "FF_SDDiskInit: Mounted SD-card as root \"%s\"\n", pcName );
+			FF_SDDiskShowPartition( pxDisk );
+		}
+	} while( 0 );
+
+	return pxDisk;
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t FF_SDDiskFormat( FF_Disk_t *pxDisk, BaseType_t aPart )
+{
+FF_Error_t xError;
+BaseType_t xReturn = 0;
+
+	FF_SDDiskUnmount( pxDisk );
+	{
+		/* Format the drive */
+		xError = FF_Format( pxDisk, aPart, pdFALSE, pdFALSE);  // Try FAT32 with large clusters
+		if( FF_isERR( xError ) )
+		{
+			FF_PRINTF( "FF_SDDiskFormat: %s\n", (const char*)FF_GetErrMessage( xError ) );
+			return 0;
+		}
+		else
+		{
+			FF_PRINTF( "FF_SDDiskFormat: OK, now remounting\n" );
+			pxDisk->xStatus.bPartitionNumber = aPart;
+			xError = FF_SDDiskMount( pxDisk );
+			FF_PRINTF( "FF_SDDiskFormat: rc %08x\n", ( unsigned )xError );
+			if( FF_isERR( xError ) == pdFALSE )
+			{
+				xReturn = 1;
+				FF_SDDiskShowPartition( pxDisk );
+			}
+		}
+	}
+	return xReturn;
+}
+/*-----------------------------------------------------------*/
+
+/* Unmount the volume */
+BaseType_t FF_SDDiskUnmount( FF_Disk_t *pxDisk )
+{
+FF_Error_t xFFError;
+BaseType_t xReturn = 1;
+
+	if( ( pxDisk != NULL ) && ( pxDisk->xStatus.bIsMounted != pdFALSE ) )
+	{
+		pxDisk->xStatus.bIsMounted = pdFALSE;
+		xFFError = FF_Unmount( pxDisk );
+		FF_PRINTF( "FF_SDDiskUnmount: rc %08x\n", ( unsigned )xFFError );
+		if( FF_isERR( xFFError ) )
+		{
+			xReturn = 0;
+		}
+		else
+		{
+			FF_PRINTF( "Drive unmounted\n" );
+		}
+	}
+
+	return xReturn;
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t FF_SDDiskReinit( FF_Disk_t *pxDisk )
+{
+int iStatus = vSDMMC_Init( 0 ); /* Hard coded index. */
+
+	/*_RB_ parameter not used. */
+	( void ) pxDisk;
+
+	FF_PRINTF( "FF_SDDiskReinit: rc %08x\n", ( unsigned )iStatus );
+	return iStatus;
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t FF_SDDiskMount( FF_Disk_t *pxDisk )
+{
+FF_Error_t xFFError;
+BaseType_t xReturn = 1;
+
+	/* Mount the partition */
+	xFFError = FF_Mount( pxDisk, pxDisk->xStatus.bPartitionNumber );
+
+	if( FF_isERR( xFFError ) )
+	{
+		FF_PRINTF( "FF_SDDiskMount: %08lX errno %d\n", xFFError, prvFFErrorToErrno( xFFError ) );
+		xReturn = 0;
+	}
+	else
+	{
+		pxDisk->xStatus.bIsMounted = pdTRUE;
+		FF_PRINTF( "****** FreeRTOS+FAT initialized %lu sectors\n", pxDisk->pxIOManager->xPartition.ulTotalSectors );
+	}
+
+	return xReturn;
+}
+/*-----------------------------------------------------------*/
+
+/* Get a pointer to IOMAN, which can be used for all FreeRTOS+FAT functions */
+FF_IOManager_t *sddisk_ioman( FF_Disk_t *pxDisk )
+{
+FF_IOManager_t *pxReturn;
+
+	if( ( pxDisk != NULL ) && ( pxDisk->xStatus.bIsInitialised != pdFALSE ) )
+	{
+		pxReturn = pxDisk->pxIOManager;
+	}
+	else
+	{
+		pxReturn = NULL;
+	}
+	return pxReturn;
+}
+/*-----------------------------------------------------------*/
+
+/* Release all resources */
+BaseType_t FF_SDDiskDelete( FF_Disk_t *pxDisk )
+{
+	if( pxDisk != NULL )
+	{
+		pxDisk->ulSignature = 0;
+		pxDisk->xStatus.bIsInitialised = 0;
+		if( pxDisk->pxIOManager != NULL )
+		{
+			if( FF_Mounted( pxDisk->pxIOManager ) != pdFALSE )
+			{
+				FF_Unmount( pxDisk );
+			}
+			FF_DeleteIOManager( pxDisk->pxIOManager );
+		}
+
+		vPortFree( pxDisk );
+	}
+	return 1;
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t FF_SDDiskShowPartition( FF_Disk_t *pxDisk )
+{
+FF_Error_t xError;
+uint64_t ullFreeSectors;
+uint32_t ulTotalSizeMB, ulFreeSizeMB;
+int iPercentageFree;
+FF_IOManager_t *pxIOManager;
+const char *pcTypeName = "unknown type";
+BaseType_t xReturn = pdPASS;
+
+	if( pxDisk == NULL )
+	{
+		xReturn = pdFAIL;
+	}
+	else
+	{
+		pxIOManager = pxDisk->pxIOManager;
+
+		FF_PRINTF( "Reading FAT and calculating Free Space\n" );
+
+		switch( pxIOManager->xPartition.ucType )
+		{
+			case FF_T_FAT12:
+				pcTypeName = "FAT12";
+				break;
+
+			case FF_T_FAT16:
+				pcTypeName = "FAT16";
+				break;
+
+			case FF_T_FAT32:
+				pcTypeName = "FAT32";
+				break;
+
+			default:
+				pcTypeName = "UNKOWN";
+				break;
+		}
+
+		FF_GetFreeSize( pxIOManager, &xError );
+
+		ullFreeSectors = pxIOManager->xPartition.ulFreeClusterCount * pxIOManager->xPartition.ulSectorsPerCluster;
+		iPercentageFree = ( int ) ( ( HUNDRED_64_BIT * ullFreeSectors + pxIOManager->xPartition.ulDataSectors / 2 ) /
+			( ( uint64_t )pxIOManager->xPartition.ulDataSectors ) );
+
+		ulTotalSizeMB = pxIOManager->xPartition.ulDataSectors / SECTORS_PER_MB;
+		ulFreeSizeMB = ( uint32_t ) ( ullFreeSectors / SECTORS_PER_MB );
+
+		/* It is better not to use the 64-bit format such as %Lu because it
+		might not be implemented. */
+		FF_PRINTF( "Partition Nr   %8u\n", pxDisk->xStatus.bPartitionNumber );
+		FF_PRINTF( "Type           %8s (%u)\n", pcTypeName, pxIOManager->xPartition.ucType );
+		FF_PRINTF( "VolLabel       '%8s' \n", pxIOManager->xPartition.pcVolumeLabel );
+		FF_PRINTF( "TotalSectors   %8lu\n", pxIOManager->xPartition.ulTotalSectors );
+		FF_PRINTF( "DataSectors    %8lu\n", pxIOManager->xPartition.ulDataSectors );
+		FF_PRINTF( "SecsPerCluster %8lu\n", pxIOManager->xPartition.ulSectorsPerCluster );
+		FF_PRINTF( "Size           %8lu MB\n", ulTotalSizeMB );
+		FF_PRINTF( "FreeSize       %8lu MB ( %d perc free )\n", ulFreeSizeMB, iPercentageFree );
+		FF_PRINTF( "BeginLBA       %8lu\n", pxIOManager->xPartition.ulBeginLBA );
+		FF_PRINTF( "FATBeginLBA    %8lu\n", pxIOManager->xPartition.ulFATBeginLBA );
+	}
+
+	return xReturn;
+}
+/*-----------------------------------------------------------*/
+
+#if( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 )
+	static void vInstallInterrupt( void )
+	{
+		/* Install an interrupt handler for SDIO_0 */
+		XScuGic_RegisterHandler( INTC_BASE_ADDR, SCUGIC_SDIO_0_INTR,
+			( Xil_ExceptionHandler )XSdPs_IntrHandler,
+			( void * )pxSDCardInstance );
+
+		/* Enable this interrupt. */
+		XScuGic_EnableIntr( INTC_DIST_BASE_ADDR, SCUGIC_SDIO_0_INTR );
+
+		/* Choose the signals. */
+		XSdPs_WriteReg16(pxSDCardInstance->Config.BaseAddress,
+				XSDPS_NORM_INTR_SIG_EN_OFFSET,
+				XSDPS_INTR_NORMAL_ENABLE );
+		XSdPs_WriteReg16(pxSDCardInstance->Config.BaseAddress,
+				XSDPS_ERR_INTR_SIG_EN_OFFSET,
+				0x0 );
+	}
+#endif /* ffconfigSDIO_DRIVER_USES_INTERRUPT */
+/*-----------------------------------------------------------*/
+
+static int vSDMMC_Init( int iDriveNumber )
+{
+int iReturnCode, iStatus;
+XSdPs_Config *SdConfig;
+
+	/*_RB_ Function name not following convention, parameter not used, parameter
+	using plain int type. */
+
+
+	/* Open a do {} while(0) loop to allow the use of break. */
+	do
+	{
+		/* Check if card is in the socket */
+		iStatus = vSDMMC_Status( iDriveNumber );
+		if( ( iStatus & STA_NODISK ) != 0 )
+		{
+			break;
+		}
+
+		/* Assume that the initialisation will fail: set the 'STA_NOINIT' bit. */
+		iStatus |= STA_NOINIT;
+
+		/* Initialize the host controller */
+		SdConfig = XSdPs_LookupConfig(SD_DEVICE_ID);
+		if( SdConfig == NULL )
+		{
+			break;
+		}
+
+		iReturnCode = XSdPs_CfgInitialize(pxSDCardInstance, SdConfig, SdConfig->BaseAddress);
+		if( iReturnCode != XST_SUCCESS )
+		{
+			break;
+		}
+
+		#if( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 )
+		{
+			vInstallInterrupt();
+		}
+		#endif	/* ffconfigSDIO_DRIVER_USES_INTERRUPT */
+		iReturnCode = XSdPs_CardInitialize( pxSDCardInstance );
+		if( iReturnCode != XST_SUCCESS )
+		{
+			break;
+		}
+
+		/* Disk is initialized OK: clear the 'STA_NOINIT' bit. */
+		iStatus &= ~( STA_NOINIT );
+	} while( 0 );
+
+	sd_disk_status = iStatus;
+
+	return iStatus;
+}
+/*-----------------------------------------------------------*/
+
+static int vSDMMC_Status( int iDriveNumber )
+{
+int iStatus = sd_disk_status;
+u32 ulStatusReg;
+
+	/*_RB_ Function name not following convention, parameter not used, parameter
+	using plain int type. */
+	( void ) iDriveNumber;
+
+	ulStatusReg = XSdPs_GetPresentStatusReg( XPAR_XSDPS_0_BASEADDR );
+	if( ( ulStatusReg & XSDPS_PSR_CARD_INSRT_MASK ) == 0 )
+	{
+		iStatus = STA_NODISK | STA_NOINIT;
+	}
+	else
+	{
+		iStatus &= ~STA_NODISK;
+		if( ( ulStatusReg & XSDPS_PSR_WPS_PL_MASK ) != 0 )
+		{
+			iStatus &= ~STA_PROTECT;
+		}
+		else
+		{
+			iStatus |= STA_PROTECT;
+		}
+	}
+
+	sd_disk_status = iStatus;
+	return iStatus;
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t FF_SDDiskInserted( BaseType_t xDriveNr )
+{
+BaseType_t xReturn;
+int iStatus;
+
+	/* Check if card is in the socket */
+	iStatus = vSDMMC_Status( xDriveNr );
+	if( ( iStatus & STA_NODISK ) != 0 )
+	{
+		xReturn = pdFALSE;
+	}
+	else
+	{
+		xReturn = pdTRUE;
+	}
+
+	return xReturn;
+}
+
+volatile unsigned sd_int_count = 0;
+
+#if( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 )
+	volatile u32 ulSDInterruptStatus[2];
+
+	void XSdPs_IntrHandler(void *XSdPsPtr)
+	{
+	XSdPs *InstancePtr = (XSdPs *)XSdPsPtr;
+	int iIndex = InstancePtr->Config.DeviceId;
+	uint32_t ulStatusReg;
+
+		configASSERT( iIndex <= 1 );
+		sd_int_count++;
+
+		/* Read the current status. */
+		ulStatusReg = XSdPs_ReadReg( InstancePtr->Config.BaseAddress, XSDPS_NORM_INTR_STS_OFFSET );
+
+		/* Write to clear error bits. */
+		XSdPs_WriteReg( InstancePtr->Config.BaseAddress, XSDPS_NORM_INTR_STS_OFFSET, ulStatusReg );
+
+		/* The new value must be OR-ed, if not the
+		Command Complete (CC) event might get overwritten
+		by the Transfer Complete (TC) event. */
+		ulSDInterruptStatus[ iIndex ] |= ulStatusReg;
+
+		if( ( ulStatusReg & ( XSDPS_INTR_CARD_INSRT_MASK | XSDPS_INTR_CARD_REM_MASK ) ) != 0 )
+		{
+			/* Could wake-up another task. */
+		}
+		if( xSDSemaphores[ iIndex ] != NULL )
+		{
+		BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+
+			xSemaphoreGiveFromISR( xSDSemaphores[ iIndex ], &xHigherPriorityTaskWoken );
+			if( xHigherPriorityTaskWoken != 0 )
+			{
+				portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+			}
+		}
+	}
+#endif /* ffconfigSDIO_DRIVER_USES_INTERRUPT */
+/*-----------------------------------------------------------*/
+
+#if( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 )
+	void XSdPs_ClearInterrupt( XSdPs *InstancePtr )
+	{
+	int iIndex = InstancePtr->Config.DeviceId;
+
+		configASSERT( iIndex <= 1 );
+		ulSDInterruptStatus[ iIndex ] = 0;
+	}
+#endif /* ffconfigSDIO_DRIVER_USES_INTERRUPT */
+/*-----------------------------------------------------------*/
+
+#if( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 )
+	/* Wait for an interrupt and return the 32 bits of the status register.
+	A return value of 0 means: time-out. */
+	u32 XSdPs_WaitInterrupt( XSdPs *InstancePtr, u32 ulMask, u32 ulWait )
+	{
+	u32 ulStatusReg;
+	int iIndex = InstancePtr->Config.DeviceId;
+	TickType_t xRemainingTime = pdMS_TO_TICKS( sdWAIT_INT_TIME_OUT_MS );
+	TimeOut_t xTimeOut;
+
+		if( ulWait == 0UL )
+		{
+			xRemainingTime = pdMS_TO_TICKS( sdQUICK_WAIT_INT_TIME_OUT_MS );
+		}
+
+		configASSERT( iIndex <= 1 );
+		configASSERT( xSDSemaphores[ iIndex ] != 0 );
+		vTaskSetTimeOutState( &xTimeOut );
+		/* Loop until:
+		1. Expected bit (ulMask) becomes high
+		2. Time-out reached (normally 2 seconds)
+		*/
+		do
+		{
+			if( xRemainingTime != 0 )
+			{
+				xSemaphoreTake( xSDSemaphores[ iIndex ], xRemainingTime );
+			}
+			ulStatusReg = ulSDInterruptStatus[ iIndex ];
+			if( ( ulStatusReg & XSDPS_INTR_ERR_MASK ) != 0 )
+			{
+				break;
+			}
+		}
+		while( ( xTaskCheckForTimeOut( &xTimeOut, &xRemainingTime ) == pdFALSE ) &&
+			   ( ( ulStatusReg & ulMask ) == 0 ) );
+
+		if( ( ulStatusReg & ulMask ) == 0 )
+		{
+		ulStatusReg = XSdPs_ReadReg( InstancePtr->Config.BaseAddress, XSDPS_NORM_INTR_STS_OFFSET );
+			if( ulWait != 0UL )
+			{
+				FF_PRINTF( "XSdPs_WaitInterrupt[ %d ]: Got %08lx, expect %08lx ints: %d\n",
+					iIndex,
+					ulStatusReg,
+					ulMask,
+					sd_int_count );
+			}
+		}
+
+		return ulStatusReg;
+	}
+
+#endif /* ffconfigSDIO_DRIVER_USES_INTERRUPT */
+/*-----------------------------------------------------------*/

--- a/portable/Zynq.2019.3/xsdps.c
+++ b/portable/Zynq.2019.3/xsdps.c
@@ -1,6 +1,6 @@
 /******************************************************************************
 *
-* Copyright (C) 2013 - 2015 Xilinx, Inc.  All rights reserved.
+* Copyright (C) 2013 - 2019 Xilinx, Inc.  All rights reserved.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -12,28 +12,22 @@
 * The above copyright notice and this permission notice shall be included in
 * all copies or substantial portions of the Software.
 *
-* Use of the Software is limited solely to applications:
-* (a) running on a Xilinx device, or
-* (b) that interact with a Xilinx device through a bus or interconnect.
-*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-* XILINX  BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF
-* OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
+* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
 *
-* Except as contained in this notice, the name of the Xilinx shall not be used
-* in advertising or otherwise to promote the sale, use or other dealings in
-* this Software without prior written authorization from Xilinx.
+*
 *
 ******************************************************************************/
 /*****************************************************************************/
 /**
 *
 * @file xsdps.c
-* @addtogroup sdps_v2_5
+* @addtogroup sdps_v3_8
 * @{
 *
 * Contains the interface functions of the XSdPs driver.
@@ -60,6 +54,48 @@
 * 2.5 	sg	   07/09/15 Added SD 3.0 features
 *       kvn    07/15/15 Modified the code according to MISRAC-2012.
 * 2.6   sk     10/12/15 Added support for SD card v1.0 CR# 840601.
+* 2.7   sk     11/24/15 Considered the slot type befoe checking CD/WP pins.
+*       sk     12/10/15 Added support for MMC cards.
+*       sk     02/16/16 Corrected the Tuning logic.
+*       sk     03/01/16 Removed Bus Width check for eMMC. CR# 938311.
+* 2.8   sk     05/03/16 Standard Speed for SD to 19MHz in ZynqMPSoC. CR#951024
+* 3.0   sk     06/09/16 Added support for mkfs to calculate sector count.
+*       sk     07/16/16 Added support for UHS modes.
+*       sk     07/07/16 Used usleep API for both arm and microblaze.
+*       sk     07/16/16 Added Tap delays accordingly to different SD/eMMC
+*                       operating modes.
+* 3.1   mi     09/07/16 Removed compilation warnings with extra compiler flags.
+*       sk     10/13/16 Reduced the delay during power cycle to 1ms as per spec
+*       sk     10/19/16 Used emmc_hwreset pin to reset eMMC.
+*       sk     11/07/16 Enable Rst_n bit in ext_csd reg if not enabled.
+* 3.2   sk     11/30/16 Modified the voltage switching sequence as per spec.
+*       sk     02/01/17 Added HSD and DDR mode support for eMMC.
+*       vns    02/09/17 Added ARMA53_32 support for ZynqMP CR#968397
+*       sk     03/20/17 Add support for EL1 non-secure mode.
+* 3.3   mn     05/17/17 Add support for 64bit DMA addressing
+*       mn     07/17/17 Add support for running SD at 200MHz
+*       mn     07/26/17 Fixed compilation warnings
+*       mn     08/07/17 Modify driver to support 64-bit DMA in arm64 only
+*       mn     08/17/17 Added CCI support for A53 and disabled data cache
+*                       operations when it is enabled.
+*       mn     08/22/17 Updated for Word Access System support
+*       mn     09/06/17 Resolved compilation errors with IAR toolchain
+*       mn     09/26/17 Added UHS_MODE_ENABLE macro to enable UHS mode
+* 3.4   mn     10/17/17 Use different commands for single and multi block
+*                       transfers
+*       mn     03/02/18 Move UHS macro check to SD card initialization routine
+* 3.5   mn     04/18/18 Resolve compilation warnings for sdps driver
+* 3.6   mn     07/06/18 Fix Cppcheck and Doxygen warnings for sdps driver
+*       mn     08/01/18 Add support for using 64Bit DMA with 32-Bit Processor
+*       mn     08/01/18 Add cache invalidation call before returning from
+*                       ReadPolled API
+*       mn     08/14/18 Resolve compilation warnings for ARMCC toolchain
+*       mn     10/01/18 Change Expected Response for CMD3 to R1 for MMC
+*       mus    11/05/18 Support 64 bit DMA addresses for Microblaze-X platform.
+* 3.7   mn     02/01/19 Add support for idling of SDIO
+*       aru    03/12/19 Modified the code according to MISRAC-2012.
+* 3.8   mn     04/12/19 Modified TapDelay code for supporting ZynqMP and Versal
+*       mn     09/17/19 Modified ADMA handling API for 32bit and 64bit addresses
 * </pre>
 *
 ******************************************************************************/
@@ -101,35 +137,41 @@
 #define XSDPS_CMD1_HIGH_VOL	0x00FF8000U
 #define XSDPS_CMD1_DUAL_VOL	0x00FF8010U
 #define HIGH_SPEED_SUPPORT	0x2U
+#define UHS_SDR50_SUPPORT	0x4U
 #define WIDTH_4_BIT_SUPPORT	0x4U
 #define SD_CLK_25_MHZ		25000000U
+#define SD_CLK_19_MHZ		19000000U
 #define SD_CLK_26_MHZ		26000000U
 #define EXT_CSD_DEVICE_TYPE_BYTE	196U
+#define EXT_CSD_SEC_COUNT_BYTE1		212U
+#define EXT_CSD_SEC_COUNT_BYTE2		213U
+#define EXT_CSD_SEC_COUNT_BYTE3		214U
+#define EXT_CSD_SEC_COUNT_BYTE4		215U
 #define EXT_CSD_DEVICE_TYPE_HIGH_SPEED			0x2U
 #define EXT_CSD_DEVICE_TYPE_DDR_1V8_HIGH_SPEED	0x4U
 #define EXT_CSD_DEVICE_TYPE_DDR_1V2_HIGH_SPEED	0x8U
 #define EXT_CSD_DEVICE_TYPE_SDR_1V8_HS200		0x10U
 #define EXT_CSD_DEVICE_TYPE_SDR_1V2_HS200		0x20U
+#define CSD_SPEC_VER_3		0x3U
+#define SCR_SPEC_VER_3		0x80U
+#define ADDRESS_BEYOND_32BIT	0x100000000U
 
-/* Note: Remove this once fixed */
-#define UHS_BROKEN
+/**************************** Type Definitions *******************************/
 
 #ifndef ffconfigWRITE_PAUSE_USEC
 	#define	ffconfigWRITE_PAUSE_USEC	500UL
 #endif
 
-/**************************** Type Definitions *******************************/
-
+/***************** Macros (Inline Functions) Definitions *********************/
 
 /************************** Function Prototypes ******************************/
 u32 XSdPs_FrameCmd(XSdPs *InstancePtr, u32 Cmd);
 s32 XSdPs_CmdTransfer(XSdPs *InstancePtr, u32 Cmd, u32 Arg, u32 BlkCnt);
 void XSdPs_SetupADMA2DescTbl(XSdPs *InstancePtr, u32 BlkCnt, const u8 *Buff);
+void XSdPs_SetupADMA2DescTbl64Bit(XSdPs *InstancePtr, u32 BlkCnt);
 extern s32 XSdPs_Uhs_ModeInit(XSdPs *InstancePtr, u8 Mode);
 static s32 XSdPs_IdentifyCard(XSdPs *InstancePtr);
-#ifndef UHS_BROKEN
-	static s32 XSdPs_Switch_Voltage(XSdPs *InstancePtr);
-#endif
+static s32 XSdPs_Switch_Voltage(XSdPs *InstancePtr);
 
 #if( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 )
 	/* Declared in ff_sddisk.c :
@@ -145,6 +187,7 @@ static s32 XSdPs_IdentifyCard(XSdPs *InstancePtr);
 	#error Please define ffconfigSDIO_DRIVER_USES_INTERRUPT
 #endif
 
+u16 TransferMode;
 /*****************************************************************************/
 /**
 *
@@ -182,31 +225,53 @@ s32 XSdPs_CfgInitialize(XSdPs *InstancePtr, XSdPs_Config *ConfigPtr,
 {
 	s32 Status;
 	u8 PowerLevel;
+	u8 ReadReg;
 
 	Xil_AssertNonvoid(InstancePtr != NULL);
 	Xil_AssertNonvoid(ConfigPtr != NULL);
 
 	/* Set some default values. */
+	InstancePtr->Config.DeviceId = ConfigPtr->DeviceId;
 	InstancePtr->Config.BaseAddress = EffectiveAddr;
 	InstancePtr->Config.InputClockHz = ConfigPtr->InputClockHz;
 	InstancePtr->IsReady = XIL_COMPONENT_IS_READY;
 	InstancePtr->Config.CardDetect =  ConfigPtr->CardDetect;
 	InstancePtr->Config.WriteProtect =  ConfigPtr->WriteProtect;
+	InstancePtr->Config.BusWidth = ConfigPtr->BusWidth;
+	InstancePtr->Config.BankNumber = ConfigPtr->BankNumber;
+	InstancePtr->Config.HasEMIO = ConfigPtr->HasEMIO;
+	InstancePtr->Config.IsCacheCoherent = ConfigPtr->IsCacheCoherent;
+	InstancePtr->SectorCount = 0U;
+	InstancePtr->Mode = XSDPS_DEFAULT_SPEED_MODE;
+	InstancePtr->OTapDelay = 0U;
+	InstancePtr->ITapDelay = 0U;
+	InstancePtr->Dma64BitAddr = 0U;
 
-	/* Disable bus power */
-	XSdPs_WriteReg8(InstancePtr->Config.BaseAddress,
-			XSDPS_POWER_CTRL_OFFSET, 0U);
+	/* Disable bus power and issue emmc hw reset */
+	if ((XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_HOST_CTRL_VER_OFFSET) & XSDPS_HC_SPEC_VER_MASK) ==
+			XSDPS_HC_SPEC_V3) {
+		XSdPs_WriteReg8(InstancePtr->Config.BaseAddress,
+				XSDPS_POWER_CTRL_OFFSET, XSDPS_PC_EMMC_HW_RST_MASK);
+	} else {
+		XSdPs_WriteReg8(InstancePtr->Config.BaseAddress,
+				XSDPS_POWER_CTRL_OFFSET, 0x0);
+	}
 
-	vTaskDelay( pdMS_TO_TICKS( 1000UL ) );
+	/* Delay to poweroff card */
+    (void)usleep(1000U);
+
 	/* "Software reset for all" is initiated */
 	XSdPs_WriteReg8(InstancePtr->Config.BaseAddress, XSDPS_SW_RST_OFFSET,
 			XSDPS_SWRST_ALL_MASK);
 
-	/*
-	 * Proceed with initialization only after reset is complete
-	 */
-	while (XSdPs_ReadReg8(InstancePtr->Config.BaseAddress,
-			XSDPS_SW_RST_OFFSET) & XSDPS_SWRST_ALL_MASK);
+	/* Proceed with initialization only after reset is complete */
+	ReadReg = XSdPs_ReadReg8(InstancePtr->Config.BaseAddress,
+				XSDPS_SW_RST_OFFSET);
+	while ((ReadReg & XSDPS_SWRST_ALL_MASK) != 0U) {
+		ReadReg = XSdPs_ReadReg8(InstancePtr->Config.BaseAddress,
+				XSDPS_SW_RST_OFFSET);
+	}
 	/* Host Controller version is read. */
 	 InstancePtr->HC_Version =
 			(u8)(XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
@@ -220,9 +285,24 @@ s32 XSdPs_CfgInitialize(XSdPs *InstancePtr, XSdPs_Config *ConfigPtr,
 						XSDPS_CAPS_OFFSET);
 
 	/* Select voltage and enable bus power. */
-	XSdPs_WriteReg8(InstancePtr->Config.BaseAddress,
-			XSDPS_POWER_CTRL_OFFSET,
-			XSDPS_PC_BUS_VSEL_3V3_MASK | XSDPS_PC_BUS_PWR_MASK);
+	if (InstancePtr->HC_Version == XSDPS_HC_SPEC_V3) {
+		XSdPs_WriteReg8(InstancePtr->Config.BaseAddress,
+				XSDPS_POWER_CTRL_OFFSET,
+				(XSDPS_PC_BUS_VSEL_3V3_MASK | XSDPS_PC_BUS_PWR_MASK) &
+				~XSDPS_PC_EMMC_HW_RST_MASK);
+	} else {
+		XSdPs_WriteReg8(InstancePtr->Config.BaseAddress,
+				XSDPS_POWER_CTRL_OFFSET,
+				XSDPS_PC_BUS_VSEL_3V3_MASK | XSDPS_PC_BUS_PWR_MASK);
+	}
+
+	/* Delay before issuing the command after emmc reset */
+	if (InstancePtr->HC_Version == XSDPS_HC_SPEC_V3) {
+		if ((InstancePtr->Host_Caps & XSDPS_CAPS_SLOT_TYPE_MASK) ==
+				XSDPS_CAPS_EMB_SLOT) {
+			usleep(200);
+		}
+	}
 
 	/* Change the clock frequency to 400 KHz */
 	Status = XSdPs_Change_ClkFreq(InstancePtr, XSDPS_CLK_400_KHZ);
@@ -245,10 +325,18 @@ s32 XSdPs_CfgInitialize(XSdPs *InstancePtr, XSdPs_Config *ConfigPtr,
 	XSdPs_WriteReg8(InstancePtr->Config.BaseAddress,
 			XSDPS_POWER_CTRL_OFFSET,
 			PowerLevel | XSDPS_PC_BUS_PWR_MASK);
-	/* Enable ADMA2 in 64bit mode. */
-	XSdPs_WriteReg8(InstancePtr->Config.BaseAddress,
-			XSDPS_HOST_CTRL1_OFFSET,
-			XSDPS_HC_DMA_ADMA2_32_MASK);
+
+	if (InstancePtr->HC_Version == XSDPS_HC_SPEC_V3) {
+		/* Enable ADMA2 in 64bit mode. */
+		XSdPs_WriteReg8(InstancePtr->Config.BaseAddress,
+				XSDPS_HOST_CTRL1_OFFSET,
+				XSDPS_HC_DMA_ADMA2_64_MASK);
+	} else {
+		/* Enable ADMA2 in 32bit mode. */
+		XSdPs_WriteReg8(InstancePtr->Config.BaseAddress,
+				XSDPS_HOST_CTRL1_OFFSET,
+				XSDPS_HC_DMA_ADMA2_32_MASK);
+	}
 
 	/* Enable all interrupt status except card interrupt initially */
 	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
@@ -269,10 +357,8 @@ s32 XSdPs_CfgInitialize(XSdPs *InstancePtr, XSdPs_Config *ConfigPtr,
 	 * Transfer mode register - default value
 	 * DMA enabled, block count enabled, data direction card to host(read)
 	 */
-	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
-			XSDPS_XFER_MODE_OFFSET,
-			XSDPS_TM_DMA_EN_MASK | XSDPS_TM_BLK_CNT_EN_MASK |
-			XSDPS_TM_DAT_DIR_SEL_MASK);
+	TransferMode = XSDPS_TM_DMA_EN_MASK | XSDPS_TM_BLK_CNT_EN_MASK |
+			XSDPS_TM_DAT_DIR_SEL_MASK;
 
 	/* Set block size to 512 by default */
 	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
@@ -318,20 +404,29 @@ s32 XSdPs_SdCardInitialize(XSdPs *InstancePtr)
 	u32 CSD[4];
 	u32 Arg;
 	u8 ReadReg;
+	u32 BlkLen, DeviceSize, Mult;
 
 	Xil_AssertNonvoid(InstancePtr != NULL);
 	Xil_AssertNonvoid(InstancePtr->IsReady == XIL_COMPONENT_IS_READY);
+FF_PRINTF( "XSdPs_SdCardInitialize\n"  );
+#ifndef UHS_MODE_ENABLE
+	InstancePtr->Config.BusWidth = XSDPS_WIDTH_4;
+#endif
 
-	if(InstancePtr->Config.CardDetect != 0U) {
-		/*
-		 * Check the present state register to make sure
-		 * card is inserted and detected by host controller
-		 */
-		PresentStateReg = XSdPs_ReadReg(InstancePtr->Config.BaseAddress,
-				XSDPS_PRES_STATE_OFFSET);
-		if ((PresentStateReg & XSDPS_PSR_CARD_INSRT_MASK) == 0U)	{
-			Status = XST_FAILURE;
-			goto RETURN_PATH;
+	if ((InstancePtr->HC_Version != XSDPS_HC_SPEC_V3) ||
+				((InstancePtr->Host_Caps & XSDPS_CAPS_SLOT_TYPE_MASK)
+				!= XSDPS_CAPS_EMB_SLOT)) {
+		if(InstancePtr->Config.CardDetect != 0U) {
+			/*
+			 * Check the present state register to make sure
+			 * card is inserted and detected by host controller
+			 */
+			PresentStateReg = XSdPs_ReadReg(InstancePtr->Config.BaseAddress,
+					XSDPS_PRES_STATE_OFFSET);
+			if ((PresentStateReg & XSDPS_PSR_CARD_INSRT_MASK) == 0U)	{
+				Status = XST_FAILURE;
+				goto RETURN_PATH;
+			}
 		}
 	}
 
@@ -341,6 +436,7 @@ s32 XSdPs_SdCardInitialize(XSdPs *InstancePtr)
 		Status = XST_FAILURE;
 		goto RETURN_PATH;
 	}
+FF_PRINTF( "CMD0 : %d\n", Status );
 
 	/*
 	 * CMD8; response expected
@@ -348,6 +444,7 @@ s32 XSdPs_SdCardInitialize(XSdPs *InstancePtr)
 	 */
 	Status = XSdPs_CmdTransfer(InstancePtr, CMD8,
 			XSDPS_CMD8_VOL_PATTERN, 0U);
+FF_PRINTF( "CMD8 : %d\n", Status );
 	if ((Status != XST_SUCCESS) && (Status != XSDPS_CT_ERROR)) {
 		Status = XST_FAILURE;
 		goto RETURN_PATH;
@@ -375,7 +472,7 @@ s32 XSdPs_SdCardInitialize(XSdPs *InstancePtr)
 	else {
 		InstancePtr->Card_Version = XSDPS_SD_VER_2_0;
 	}
-
+FF_PRINTF( "Card_Version %d\n", InstancePtr->Card_Version);
 	RespOCR = 0U;
 	/* Send ACMD41 while card is still busy with power up */
 	while ((RespOCR & XSDPS_RESPOCR_READY) == 0U) {
@@ -385,9 +482,17 @@ s32 XSdPs_SdCardInitialize(XSdPs *InstancePtr)
 			goto RETURN_PATH;
 		}
 
-        Arg = XSDPS_ACMD41_HCS | XSDPS_ACMD41_3V3 | (0x1FFU << 15U);
-		if (InstancePtr->HC_Version == XSDPS_HC_SPEC_V3) {
-		    Arg |= XSDPS_OCR_S18;
+		Arg = XSDPS_ACMD41_HCS | XSDPS_ACMD41_3V3 | (0x1FFU << 15U);
+		/*
+		 * There is no support to switch to 1.8V and use UHS mode on
+		 * 1.0 silicon
+		 */
+		if ((InstancePtr->HC_Version == XSDPS_HC_SPEC_V3) &&
+#if defined (ARMR5) || (__aarch64__) || (ARMA53_32) || (PSU_PMU)
+			(XGetPSVersion_Info() > (u32)XPS_VERSION_1) &&
+#endif
+			(InstancePtr->Config.BusWidth == XSDPS_WIDTH_8)) {
+			Arg |= XSDPS_OCR_S18;
 		}
 
 		/* 0x40300000 - Host High Capacity support & 3.3V window */
@@ -409,18 +514,14 @@ s32 XSdPs_SdCardInitialize(XSdPs *InstancePtr)
 		InstancePtr->HCS = 1U;
 	}
 
-	/* There is no support to switch to 1.8V and use UHS mode on 1.0 silicon */
-#ifndef UHS_BROKEN
-    if ((RespOCR & XSDPS_OCR_S18) != 0U) {
+	if ((RespOCR & XSDPS_OCR_S18) != 0U) {
 		InstancePtr->Switch1v8 = 1U;
 		Status = XSdPs_Switch_Voltage(InstancePtr);
 		if (Status != XST_SUCCESS) {
 			Status = XST_FAILURE;
 			goto RETURN_PATH;
 		}
-
 	}
-#endif
 
 	/* CMD2 for Card ID */
 	Status = XSdPs_CmdTransfer(InstancePtr, CMD2, 0U, 0U);
@@ -429,13 +530,19 @@ s32 XSdPs_SdCardInitialize(XSdPs *InstancePtr)
 		goto RETURN_PATH;
 	}
 
-	InstancePtr->CardID[0] = XSdPs_ReadReg(InstancePtr->Config.BaseAddress, XSDPS_RESP0_OFFSET);
-	InstancePtr->CardID[1] = XSdPs_ReadReg(InstancePtr->Config.BaseAddress, XSDPS_RESP1_OFFSET);
-	InstancePtr->CardID[2] = XSdPs_ReadReg(InstancePtr->Config.BaseAddress, XSDPS_RESP2_OFFSET);
-	InstancePtr->CardID[3] = XSdPs_ReadReg(InstancePtr->Config.BaseAddress, XSDPS_RESP3_OFFSET);
-
-	do
-	{
+	InstancePtr->CardID[0] =
+			XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_RESP0_OFFSET);
+	InstancePtr->CardID[1] =
+			XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_RESP1_OFFSET);
+	InstancePtr->CardID[2] =
+			XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_RESP2_OFFSET);
+	InstancePtr->CardID[3] =
+			XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_RESP3_OFFSET);
+	do {
 		Status = XSdPs_CmdTransfer(InstancePtr, CMD3, 0U, 0U);
 		if (Status != XST_SUCCESS) {
 			Status = XST_FAILURE;
@@ -488,29 +595,44 @@ s32 XSdPs_SdCardInitialize(XSdPs *InstancePtr)
 		mmc_decode_cid( &myCSD, &myCID, resp );
 	}
 
+	/*
+	 * Card specific data is read.
+	 * Currently not used for any operation.
+	 */
+#if 0
+	CSD[0] = XSdPs_ReadReg(InstancePtr->Config.BaseAddress,
+			XSDPS_RESP0_OFFSET);
+	CSD[1] = XSdPs_ReadReg(InstancePtr->Config.BaseAddress,
+			XSDPS_RESP1_OFFSET);
+	CSD[2] = XSdPs_ReadReg(InstancePtr->Config.BaseAddress,
+			XSDPS_RESP2_OFFSET);
+	CSD[3] = XSdPs_ReadReg(InstancePtr->Config.BaseAddress,
+			XSDPS_RESP3_OFFSET);
+
+	if (((CSD[3] & CSD_STRUCT_MASK) >> 22U) == 0U) {
+		BlkLen = 1U << ((u32)(CSD[2] & READ_BLK_LEN_MASK) >> 8U);
+		Mult = 1U << ((u32)((CSD[1] & C_SIZE_MULT_MASK) >> 7U) + 2U);
+		DeviceSize = (CSD[1] & C_SIZE_LOWER_MASK) >> 22U;
+		DeviceSize |= (CSD[2] & C_SIZE_UPPER_MASK) << 10U;
+		DeviceSize = (DeviceSize + 1U) * Mult;
+		DeviceSize =  DeviceSize * BlkLen;
+		InstancePtr->SectorCount = (DeviceSize/XSDPS_BLK_SIZE_512_MASK);
+	} else if (((CSD[3] & CSD_STRUCT_MASK) >> 22U) == 1U) {
+		InstancePtr->SectorCount = (((CSD[1] & CSD_V2_C_SIZE_MASK) >> 8U) +
+										1U) * 1024U;
+	} else {
+		Status = XST_FAILURE;
+		goto RETURN_PATH;
+	}
+#endif /* 0 */
+
+FF_PRINTF("Sector count %lu\n", InstancePtr->SectorCount );
 	Status = XST_SUCCESS;
 
 RETURN_PATH:
 	return Status;
 
 }
-
-/*
- * This driver will hang if the SD-card gets extracted while doing i/o.
- * The driver waits for either 'XSDPS_INTR_CC_MASK', 'XSDPS_INTR_TC_MASK',
- * or 'XSDPS_INTR_ERR_MASK'.
- * None of the bits will ever get set and the program gets stuck here.
- * The number of polls will be counted, and when a high number is reached,
- * an error will be returned.
- * This time-out will happen after about 2 seconds.
- *
- * A better solution is to define 'ffconfigSDIO_DRIVER_USES_INTERRUPT'. The CPU
- * won't poll and the task will block while the MMC peripheral is working.
- */
-
-#if( ffconfigSDIO_DRIVER_USES_INTERRUPT == 0 )
-	#define	POLLCOUNT_MAX	0x800000
-#endif
 
 /*****************************************************************************/
 /**
@@ -534,18 +656,20 @@ s32 XSdPs_CardInitialize(XSdPs *InstancePtr)
 {
 #ifdef __ICCARM__
 #pragma data_alignment = 32
-static u8 ExtCsd[512];
-#pragma data_alignment = 4
+	static u8 ExtCsd[512];
+#pragma data_alignment = 32
+	static u8 SCR[8] = { 0U };
 #else
-static u8 ExtCsd[512] __attribute__ ((aligned(32)));
+	static u8 ExtCsd[512] __attribute__ ((aligned(32)));
+	static u8 SCR[8] __attribute__ ((aligned(32))) = { 0U };
 #endif
-	u8 SCR[8] = { 0U };
 	u8 ReadBuff[64] = { 0U };
 	s32 Status;
+	u32 Arg;
 
 	Xil_AssertNonvoid(InstancePtr != NULL);
 	Xil_AssertNonvoid(InstancePtr->IsReady == XIL_COMPONENT_IS_READY);
-
+FF_PRINTF( "XSdPs_CardInitialize\n"  );
 	/* Default settings */
 	InstancePtr->BusWidth = XSDPS_1_BIT_WIDTH;
 	InstancePtr->CardType = XSDPS_CARD_SD;
@@ -578,7 +702,16 @@ static u8 ExtCsd[512] __attribute__ ((aligned(32)));
 		}
 
 		/* Change clock to default clock 25MHz */
-		InstancePtr->BusSpeed = SD_CLK_25_MHZ;
+		/*
+		 * SD default speed mode timing should be closed at 19 MHz.
+		 * The reason for this is SD requires a voltage level shifter.
+		 * This limitation applies to ZynqMPSoC.
+		 */
+		if (InstancePtr->HC_Version == XSDPS_HC_SPEC_V3) {
+			InstancePtr->BusSpeed = SD_CLK_19_MHZ;
+		} else {
+			InstancePtr->BusSpeed = SD_CLK_25_MHZ;
+		}
 		Status = XSdPs_Change_ClkFreq(InstancePtr, InstancePtr->BusSpeed);
 		if (Status != XST_SUCCESS) {
 			Status = XST_FAILURE;
@@ -632,35 +765,100 @@ static u8 ExtCsd[512] __attribute__ ((aligned(32)));
 			}
 		}
 
-		if ((InstancePtr->Switch1v8 != 0U) &&
-				(InstancePtr->BusWidth == XSDPS_4_BIT_WIDTH)) {
-			/* Set UHS-I SDR104 mode */
-			Status = XSdPs_Uhs_ModeInit(InstancePtr,
-					XSDPS_UHS_SPEED_MODE_SDR104);
-			if (Status != XST_SUCCESS) {
+		/* Get speed supported by device */
+		Status = XSdPs_Get_BusSpeed(InstancePtr, ReadBuff);
+		if (Status != XST_SUCCESS) {
+			goto RETURN_PATH;
+		}
+
+		if (((SCR[2] & SCR_SPEC_VER_3) != 0U) &&
+			(ReadBuff[13] >= UHS_SDR50_SUPPORT) &&
+			(InstancePtr->Config.BusWidth == XSDPS_WIDTH_8) &&
+#if defined (ARMR5) || (__aarch64__) || (ARMA53_32) || (PSU_PMU)
+			(XGetPSVersion_Info() > (u32)XPS_VERSION_1) &&
+#endif
+			(InstancePtr->Switch1v8 == 0U)) {
+			u16 CtrlReg, ClockReg;
+
+			/* Stop the clock */
+			CtrlReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+					XSDPS_CLK_CTRL_OFFSET);
+			CtrlReg &= ~(XSDPS_CC_SD_CLK_EN_MASK | XSDPS_CC_INT_CLK_EN_MASK);
+			XSdPs_WriteReg16(InstancePtr->Config.BaseAddress, XSDPS_CLK_CTRL_OFFSET,
+					CtrlReg);
+
+			/* Enabling 1.8V in controller */
+			CtrlReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+					XSDPS_HOST_CTRL2_OFFSET);
+			CtrlReg |= XSDPS_HC2_1V8_EN_MASK;
+			XSdPs_WriteReg16(InstancePtr->Config.BaseAddress, XSDPS_HOST_CTRL2_OFFSET,
+					CtrlReg);
+
+			/* Wait minimum 5mSec */
+			(void)usleep(5000U);
+
+			/* Check for 1.8V signal enable bit is cleared by Host */
+			CtrlReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+						XSDPS_HOST_CTRL2_OFFSET);
+			if ((CtrlReg & XSDPS_HC2_1V8_EN_MASK) == 0U) {
 				Status = XST_FAILURE;
 				goto RETURN_PATH;
 			}
 
-		} else {
+			/* Wait for internal clock to stabilize */
+			ClockReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+						XSDPS_CLK_CTRL_OFFSET);
+			XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+						XSDPS_CLK_CTRL_OFFSET,
+						ClockReg | XSDPS_CC_INT_CLK_EN_MASK);
+			ClockReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+								XSDPS_CLK_CTRL_OFFSET);
+			while((ClockReg & XSDPS_CC_INT_CLK_STABLE_MASK) == 0U) {
+				ClockReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+							XSDPS_CLK_CTRL_OFFSET);
+			}
 
+			/* Enable SD clock */
+			ClockReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+					XSDPS_CLK_CTRL_OFFSET);
+			XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+					XSDPS_CLK_CTRL_OFFSET,
+					ClockReg | XSDPS_CC_SD_CLK_EN_MASK);
+
+			/* Wait for 1mSec */
+			(void)usleep(1000U);
+
+			InstancePtr->Switch1v8 = 1U;
+		}
+
+#if defined (ARMR5) || defined (__aarch64__) || defined (ARMA53_32) || defined (__MICROBLAZE__)
+		if (InstancePtr->Switch1v8 != 0U) {
+
+			/* Identify the UHS mode supported by card */
+			XSdPs_Identify_UhsMode(InstancePtr, ReadBuff);
+
+			/* Set UHS-I SDR104 mode */
+			Status = XSdPs_Uhs_ModeInit(InstancePtr, (u8)InstancePtr->Mode);
+			if (Status != XST_SUCCESS) {
+				goto RETURN_PATH;
+			}
+
+		} else {
+#endif
 			/*
 			 * card supports CMD6 when SD_SPEC field in SCR register
 			 * indicates that the Physical Layer Specification Version
 			 * is 1.10 or later. So for SD v1.0 cmd6 is not supported.
 			 */
 			if (SCR[0] != 0U) {
-				/* Get speed supported by device */
-				Status = XSdPs_Get_BusSpeed(InstancePtr, ReadBuff);
-				if (Status != XST_SUCCESS) {
-					Status = XST_FAILURE;
-					FF_PRINTF( "SD-card seems OK but 4-bits doesn't work. Dirty contacts ?\n" );
-					FF_PRINTF( "Or: SD-card has version v1.0 which does not support cmd6 ?\n" );
-					goto RETURN_PATH;
-				}
-
 				/* Check for high speed support */
-				if ((ReadBuff[13] & HIGH_SPEED_SUPPORT) != 0U) {
+				if (((ReadBuff[13] & HIGH_SPEED_SUPPORT) != 0U) &&
+						(InstancePtr->BusWidth >= XSDPS_4_BIT_WIDTH)) {
+					InstancePtr->Mode = XSDPS_HIGH_SPEED_MODE;
+#if defined (ARMR5) || defined (__aarch64__) || defined (ARMA53_32) || defined (__MICROBLAZE__)
+					InstancePtr->OTapDelay = SD_OTAPDLYSEL_SD_HSD;
+					InstancePtr->ITapDelay = SD_ITAPDLYSEL_HSD;
+#endif
 					Status = XSdPs_Change_BusSpeed(InstancePtr);
 					if (Status != XST_SUCCESS) {
 						Status = XST_FAILURE;
@@ -668,9 +866,12 @@ static u8 ExtCsd[512] __attribute__ ((aligned(32)));
 					}
 				}
 			}
+#if defined (ARMR5) || defined (__aarch64__) || defined (ARMA53_32) || defined (__MICROBLAZE__)
 		}
+#endif
 
-	} else if ((InstancePtr->CardType == XSDPS_CARD_MMC) &&
+	} else if (((InstancePtr->CardType == XSDPS_CARD_MMC) &&
+				(InstancePtr->Card_Version > CSD_SPEC_VER_3)) &&
 				(InstancePtr->HC_Version == XSDPS_HC_SPEC_V2)) {
 
 		Status = XSdPs_Change_BusWidth(InstancePtr);
@@ -685,13 +886,15 @@ static u8 ExtCsd[512] __attribute__ ((aligned(32)));
 			goto RETURN_PATH;
 		}
 
-		if (ExtCsd[EXT_CSD_BUS_WIDTH_BYTE] != EXT_CSD_BUS_WIDTH_4_BIT) {
-			Status = XST_FAILURE;
-			goto RETURN_PATH;
-		}
+		InstancePtr->SectorCount = ((u32)ExtCsd[EXT_CSD_SEC_COUNT_BYTE4]) << 24;
+		InstancePtr->SectorCount |= (u32)ExtCsd[EXT_CSD_SEC_COUNT_BYTE3] << 16;
+		InstancePtr->SectorCount |= (u32)ExtCsd[EXT_CSD_SEC_COUNT_BYTE2] << 8;
+		InstancePtr->SectorCount |= (u32)ExtCsd[EXT_CSD_SEC_COUNT_BYTE1];
 
-		if ((ExtCsd[EXT_CSD_DEVICE_TYPE_BYTE] &
-				EXT_CSD_DEVICE_TYPE_HIGH_SPEED) != 0U) {
+		if (((ExtCsd[EXT_CSD_DEVICE_TYPE_BYTE] &
+				EXT_CSD_DEVICE_TYPE_HIGH_SPEED) != 0U) &&
+				(InstancePtr->BusWidth >= XSDPS_4_BIT_WIDTH)) {
+			InstancePtr->Mode = XSDPS_HIGH_SPEED_MODE;
 			Status = XSdPs_Change_BusSpeed(InstancePtr);
 			if (Status != XST_SUCCESS) {
 				Status = XST_FAILURE;
@@ -724,15 +927,46 @@ static u8 ExtCsd[512] __attribute__ ((aligned(32)));
 			goto RETURN_PATH;
 		}
 
-		/* Check for 8-bit support */
-		if (ExtCsd[EXT_CSD_BUS_WIDTH_BYTE] != EXT_CSD_BUS_WIDTH_8_BIT) {
-			Status = XST_FAILURE;
-			goto RETURN_PATH;
+		InstancePtr->SectorCount = ((u32)ExtCsd[EXT_CSD_SEC_COUNT_BYTE4]) << 24;
+		InstancePtr->SectorCount |= (u32)ExtCsd[EXT_CSD_SEC_COUNT_BYTE3] << 16;
+		InstancePtr->SectorCount |= (u32)ExtCsd[EXT_CSD_SEC_COUNT_BYTE2] << 8;
+		InstancePtr->SectorCount |= (u32)ExtCsd[EXT_CSD_SEC_COUNT_BYTE1];
+
+		/* Check for card supported speed */
+		if (((ExtCsd[EXT_CSD_DEVICE_TYPE_BYTE] &
+				(EXT_CSD_DEVICE_TYPE_SDR_1V8_HS200 |
+				EXT_CSD_DEVICE_TYPE_SDR_1V2_HS200)) != 0U) &&
+				(InstancePtr->BusWidth >= XSDPS_4_BIT_WIDTH)) {
+			InstancePtr->Mode = XSDPS_HS200_MODE;
+#if defined (ARMR5) || defined (__aarch64__) || defined (ARMA53_32) || defined (__MICROBLAZE__)
+			if (InstancePtr->Config.BankNumber == 2U) {
+				InstancePtr->OTapDelay = SD_OTAPDLYSEL_HS200_B2;
+			} else {
+				InstancePtr->OTapDelay = SD_OTAPDLYSEL_HS200_B0;
+			}
+#endif
+		} else if (((ExtCsd[EXT_CSD_DEVICE_TYPE_BYTE] &
+				(EXT_CSD_DEVICE_TYPE_DDR_1V8_HIGH_SPEED |
+				EXT_CSD_DEVICE_TYPE_DDR_1V2_HIGH_SPEED)) != 0U) &&
+				(InstancePtr->BusWidth >= XSDPS_4_BIT_WIDTH)) {
+			InstancePtr->Mode = XSDPS_DDR52_MODE;
+#if defined (ARMR5) || defined (__aarch64__) || defined (ARMA53_32) || defined (__MICROBLAZE__)
+			InstancePtr->OTapDelay = SD_ITAPDLYSEL_EMMC_DDR50;
+			InstancePtr->ITapDelay = SD_ITAPDLYSEL_EMMC_DDR50;
+#endif
+		} else if (((ExtCsd[EXT_CSD_DEVICE_TYPE_BYTE] &
+				EXT_CSD_DEVICE_TYPE_HIGH_SPEED) != 0U) &&
+				(InstancePtr->BusWidth >= XSDPS_4_BIT_WIDTH)) {
+			InstancePtr->Mode = XSDPS_HIGH_SPEED_MODE;
+#if defined (ARMR5) || defined (__aarch64__) || defined (ARMA53_32) || defined (__MICROBLAZE__)
+			InstancePtr->OTapDelay = SD_OTAPDLYSEL_EMMC_HSD;
+			InstancePtr->ITapDelay = SD_ITAPDLYSEL_HSD;
+#endif
+		} else {
+			InstancePtr->Mode = XSDPS_DEFAULT_SPEED_MODE;
 		}
 
-		if ((ExtCsd[EXT_CSD_DEVICE_TYPE_BYTE] &
-				(EXT_CSD_DEVICE_TYPE_SDR_1V8_HS200 |
-				EXT_CSD_DEVICE_TYPE_SDR_1V2_HS200)) != 0U) {
+		if (InstancePtr->Mode != XSDPS_DEFAULT_SPEED_MODE) {
 			Status = XSdPs_Change_BusSpeed(InstancePtr);
 			if (Status != XST_SUCCESS) {
 				Status = XST_FAILURE;
@@ -745,17 +979,50 @@ static u8 ExtCsd[512] __attribute__ ((aligned(32)));
 				goto RETURN_PATH;
 			}
 
-			if (ExtCsd[EXT_CSD_HS_TIMING_BYTE] != EXT_CSD_HS_TIMING_HS200) {
+			if (InstancePtr->Mode == XSDPS_HS200_MODE) {
+				if (ExtCsd[EXT_CSD_HS_TIMING_BYTE] != EXT_CSD_HS_TIMING_HS200) {
+					Status = XST_FAILURE;
+					goto RETURN_PATH;
+				}
+			}
+
+			if ((InstancePtr->Mode == XSDPS_HIGH_SPEED_MODE) ||
+					(InstancePtr->Mode == XSDPS_DDR52_MODE)) {
+				if (ExtCsd[EXT_CSD_HS_TIMING_BYTE] != EXT_CSD_HS_TIMING_HIGH) {
+					Status = XST_FAILURE;
+					goto RETURN_PATH;
+				}
+
+				if (InstancePtr->Mode == XSDPS_DDR52_MODE) {
+					Status = XSdPs_Change_BusWidth(InstancePtr);
+					if (Status != XST_SUCCESS) {
+						Status = XST_FAILURE;
+						goto RETURN_PATH;
+					}
+				}
+			}
+		}
+
+		/* Enable Rst_n_Fun bit if it is disabled */
+		if(ExtCsd[EXT_CSD_RST_N_FUN_BYTE] == EXT_CSD_RST_N_FUN_TEMP_DIS) {
+			Arg = XSDPS_MMC_RST_FUN_EN_ARG;
+			Status = XSdPs_Set_Mmc_ExtCsd(InstancePtr, Arg);
+			if (Status != XST_SUCCESS) {
 				Status = XST_FAILURE;
 				goto RETURN_PATH;
 			}
 		}
-	}
-
-	Status = XSdPs_SetBlkSize(InstancePtr, XSDPS_BLK_SIZE_512_MASK);
-	if (Status != XST_SUCCESS) {
+	} else {
 		Status = XST_FAILURE;
 		goto RETURN_PATH;
+	}
+	if ((InstancePtr->Mode != XSDPS_DDR52_MODE) ||
+			(InstancePtr->CardType == XSDPS_CARD_SD)) {
+		Status = XSdPs_SetBlkSize(InstancePtr, XSDPS_BLK_SIZE_512_MASK);
+		if (Status != XST_SUCCESS) {
+			Status = XST_FAILURE;
+			goto RETURN_PATH;
+		}
 	}
 
 RETURN_PATH:
@@ -780,18 +1047,7 @@ static s32 XSdPs_IdentifyCard(XSdPs *InstancePtr)
 	Xil_AssertNonvoid(InstancePtr->IsReady == XIL_COMPONENT_IS_READY);
 
 	/* 74 CLK delay after card is powered up, before the first command. */
-#if defined (__arm__) || defined (__aarch64__)
-
 	usleep(XSDPS_INIT_DELAY);
-
-#endif
-
-#ifdef __MICROBLAZE__
-
-	/* 2 msec delay */
-	MB_Sleep(2);
-
-#endif
 
 	/* CMD0 no response expected */
 	Status = XSdPs_CmdTransfer(InstancePtr, CMD0, 0U, 0U);
@@ -801,6 +1057,7 @@ static s32 XSdPs_IdentifyCard(XSdPs *InstancePtr)
 	}
 
 	/* Host High Capacity support & High voltage window */
+	/* Midn you, for an SD-card this command should fail. */
 	Status = XSdPs_CmdTransfer(InstancePtr, CMD1,
 			XSDPS_ACMD41_HCS | XSDPS_CMD1_HIGH_VOL, 0U);
 	if (Status != XST_SUCCESS) {
@@ -841,12 +1098,11 @@ RETURN_PATH:
 * @param	InstancePtr is a pointer to the XSdPs instance.
 *
 ******************************************************************************/
-#ifndef UHS_BROKEN
 static s32 XSdPs_Switch_Voltage(XSdPs *InstancePtr)
 {
 	s32 Status;
 	u16 CtrlReg;
-	u32 ReadReg;
+	u32 ReadReg, ClockReg;
 
 	/* Send switch voltage command */
 	Status = XSdPs_CmdTransfer(InstancePtr, CMD11, 0U, 0U);
@@ -870,19 +1126,6 @@ static s32 XSdPs_Switch_Voltage(XSdPs *InstancePtr)
 	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress, XSDPS_CLK_CTRL_OFFSET,
 			CtrlReg);
 
-	/* Wait minimum 5mSec */
-#if defined (__arm__) || defined (__aarch64__)
-
-	(void)usleep(5000U);
-
-#endif
-
-#ifdef __MICROBLAZE__
-
-	MB_Sleep(5U);
-
-#endif
-
 	/* Enabling 1.8V in controller */
 	CtrlReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
 			XSDPS_HOST_CTRL2_OFFSET);
@@ -890,12 +1133,39 @@ static s32 XSdPs_Switch_Voltage(XSdPs *InstancePtr)
 	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress, XSDPS_HOST_CTRL2_OFFSET,
 			CtrlReg);
 
-	/* Start clock */
-	Status = XSdPs_Change_ClkFreq(InstancePtr, XSDPS_CLK_400_KHZ);
-	if (Status != XST_SUCCESS) {
+	/* Wait minimum 5mSec */
+	(void)usleep(5000U);
+
+	/* Check for 1.8V signal enable bit is cleared by Host */
+	CtrlReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+				XSDPS_HOST_CTRL2_OFFSET);
+	if ((CtrlReg & XSDPS_HC2_1V8_EN_MASK) == 0U) {
 		Status = XST_FAILURE;
 		goto RETURN_PATH;
 	}
+
+	/* Wait for internal clock to stabilize */
+	ClockReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+				XSDPS_CLK_CTRL_OFFSET);
+	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+				XSDPS_CLK_CTRL_OFFSET,
+				ClockReg | XSDPS_CC_INT_CLK_EN_MASK);
+	ClockReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+						XSDPS_CLK_CTRL_OFFSET);
+	while((ClockReg & XSDPS_CC_INT_CLK_STABLE_MASK) == 0U) {
+		ClockReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+					XSDPS_CLK_CTRL_OFFSET);
+	}
+
+	/* Enable SD clock */
+	ClockReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_CLK_CTRL_OFFSET);
+	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_CLK_CTRL_OFFSET,
+			ClockReg | XSDPS_CC_SD_CLK_EN_MASK);
+
+	/* Wait for 1mSec */
+	(void)usleep(1000U);
 
 	/* Wait for CMD and DATA line to go high */
 	ReadReg = XSdPs_ReadReg(InstancePtr->Config.BaseAddress,
@@ -909,7 +1179,6 @@ static s32 XSdPs_Switch_Voltage(XSdPs *InstancePtr)
 RETURN_PATH:
 	return Status;
 }
-#endif /* UHS_BROKEN */
 
 s32 XSdPs_Wait_For(XSdPs *InstancePtr, u32 Mask, u32 Wait)
 {
@@ -983,6 +1252,7 @@ s32 XSdPs_Wait_For(XSdPs *InstancePtr, u32 Mask, u32 Wait)
 * 			is in progress or command or data inhibit is set
 *
 ******************************************************************************/
+
 s32 XSdPs_CmdTransfer(XSdPs *InstancePtr, u32 Cmd, u32 Arg, u32 BlkCnt)
 {
 	u32 PresentStateReg;
@@ -1040,8 +1310,10 @@ s32 XSdPs_CmdTransfer(XSdPs *InstancePtr, u32 Cmd, u32 Arg, u32 BlkCnt)
 #if( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 )
 	XSdPs_ClearInterrupt( InstancePtr );
 #endif
-	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress, XSDPS_CMD_OFFSET,
-			(u16)CommandReg);
+	XSdPs_WriteReg(InstancePtr->Config.BaseAddress, XSDPS_XFER_MODE_OFFSET,
+			(CommandReg << 16) | TransferMode);
+//	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress, XSDPS_CMD_OFFSET,
+//			(u16)CommandReg);
 
 	Status = XSdPs_Wait_For(InstancePtr, XSDPS_INTR_CC_MASK, Cmd != CMD1);
 
@@ -1051,6 +1323,110 @@ RETURN_PATH:
 
 }
 
+#if 0 /* new version */
+s32 XSdPs_CmdTransfer(XSdPs *InstancePtr, u32 Cmd, u32 Arg, u32 BlkCnt)
+{
+	u32 PresentStateReg;
+	u32 CommandReg;
+	u32 StatusReg;
+	s32 Status;
+
+	Xil_AssertNonvoid(InstancePtr != NULL);
+	Xil_AssertNonvoid(InstancePtr->IsReady == XIL_COMPONENT_IS_READY);
+
+	/*
+	 * Check the command inhibit to make sure no other
+	 * command transfer is in progress
+	 */
+	PresentStateReg = XSdPs_ReadReg(InstancePtr->Config.BaseAddress,
+			XSDPS_PRES_STATE_OFFSET);
+	if ((PresentStateReg & XSDPS_PSR_INHIBIT_CMD_MASK) != 0U) {
+		Status = XST_FAILURE;
+		goto RETURN_PATH;
+	}
+
+	/* Write block count register */
+	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_BLK_CNT_OFFSET, (u16)BlkCnt);
+
+	XSdPs_WriteReg8(InstancePtr->Config.BaseAddress,
+			XSDPS_TIMEOUT_CTRL_OFFSET, 0xEU);
+
+	/* Write argument register */
+	XSdPs_WriteReg(InstancePtr->Config.BaseAddress,
+			XSDPS_ARGMT_OFFSET, Arg);
+
+	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_NORM_INTR_STS_OFFSET, XSDPS_NORM_INTR_ALL_MASK);
+	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_ERR_INTR_STS_OFFSET, XSDPS_ERROR_INTR_ALL_MASK);
+	/* Command register is set to trigger transfer of command */
+	CommandReg = XSdPs_FrameCmd(InstancePtr, Cmd);
+
+	/*
+	 * Mask to avoid writing to reserved bits 31-30
+	 * This is necessary because 0x80000000 is used  by this software to
+	 * distinguish between ACMD and CMD of same number
+	 */
+	CommandReg = CommandReg & 0x3FFFU;
+
+	/*
+	 * Check for data inhibit in case of command using DAT lines.
+	 * For Tuning Commands DAT lines check can be ignored.
+	 */
+	if ((Cmd != CMD21) && (Cmd != CMD19)) {
+		PresentStateReg = XSdPs_ReadReg(InstancePtr->Config.BaseAddress,
+				XSDPS_PRES_STATE_OFFSET);
+		if (((PresentStateReg & (XSDPS_PSR_INHIBIT_DAT_MASK |
+									XSDPS_PSR_INHIBIT_DAT_MASK)) != 0U) &&
+				((CommandReg & XSDPS_DAT_PRESENT_SEL_MASK) != 0U)) {
+			Status = XST_FAILURE;
+			goto RETURN_PATH;
+		}
+	}
+
+	XSdPs_WriteReg(InstancePtr->Config.BaseAddress, XSDPS_XFER_MODE_OFFSET,
+			(CommandReg << 16) | TransferMode);
+
+	/* Polling for response for now */
+	do {
+		StatusReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+					XSDPS_NORM_INTR_STS_OFFSET);
+		if ((Cmd == CMD21) || (Cmd == CMD19)) {
+			if ((XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+					XSDPS_NORM_INTR_STS_OFFSET) & XSDPS_INTR_BRR_MASK) != 0U){
+				XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+					XSDPS_NORM_INTR_STS_OFFSET, XSDPS_INTR_BRR_MASK);
+				break;
+			}
+		}
+
+		if ((StatusReg & XSDPS_INTR_ERR_MASK) != 0U) {
+			Status = (s32)XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+									XSDPS_ERR_INTR_STS_OFFSET);
+			if (((u32)Status & ~XSDPS_INTR_ERR_CT_MASK) == 0U) {
+				Status = XSDPS_CT_ERROR;
+			}
+			 /* Write to clear error bits */
+			XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+					XSDPS_ERR_INTR_STS_OFFSET,
+					XSDPS_ERROR_INTR_ALL_MASK);
+			goto RETURN_PATH;
+		}
+	} while((StatusReg & XSDPS_INTR_CC_MASK) == 0U);
+	/* Write to clear bit */
+	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_NORM_INTR_STS_OFFSET,
+			XSDPS_INTR_CC_MASK);
+
+	Status = XST_SUCCESS;
+
+RETURN_PATH:
+		return Status;
+
+}
+#endif /* 0 new version */
+
 /*****************************************************************************/
 /**
 * This function frames the Command register for a particular command.
@@ -1059,7 +1435,8 @@ RETURN_PATH:
 * This value is already shifted to be upper 16 bits and can be directly
 * OR'ed with transfer mode register value.
 *
-* @param	Command to be sent.
+* @param	InstancePtr is a pointer to the instance to be worked on.
+* @param	Cmd is the Command to be sent.
 *
 * @return	Command register value complete with response type and
 * 		data, CRC and index related flags.
@@ -1082,7 +1459,11 @@ u32 XSdPs_FrameCmd(XSdPs *InstancePtr, u32 Cmd)
 			RetVal |= RESP_R2;
 		break;
 		case CMD3:
-			RetVal |= RESP_R6;
+			if (InstancePtr->CardType == XSDPS_CARD_SD) {
+				RetVal |= RESP_R6;
+			} else {
+				RetVal |= RESP_R1;
+			}
 		break;
 		case CMD4:
 			RetVal |= RESP_NONE;
@@ -1116,7 +1497,11 @@ u32 XSdPs_FrameCmd(XSdPs *InstancePtr, u32 Cmd)
 		case CMD11:
 		case CMD10:
 		case CMD12:
+			RetVal |= RESP_R1;
+		break;
 		case ACMD13:
+			RetVal |= RESP_R1 | (u32)XSDPS_DAT_PRESENT_SEL_MASK;
+		break;
 		case CMD16:
 			RetVal |= RESP_R1;
 		break;
@@ -1131,6 +1516,7 @@ u32 XSdPs_FrameCmd(XSdPs *InstancePtr, u32 Cmd)
 		case CMD24:
 		case CMD25:
 			RetVal |= RESP_R1 | (u32)XSDPS_DAT_PRESENT_SEL_MASK;
+		break;
 		case ACMD41:
 			RetVal |= RESP_R3;
 		break;
@@ -1175,13 +1561,17 @@ s32 XSdPs_ReadPolled(XSdPs *InstancePtr, u32 Arg, u32 BlkCnt, u8 *Buff)
 	s32 Status;
 	u32 PresentStateReg;
 
-	if(InstancePtr->Config.CardDetect != 0U) {
-		/* Check status to ensure card is initialized */
-		PresentStateReg = XSdPs_ReadReg(InstancePtr->Config.BaseAddress,
-				XSDPS_PRES_STATE_OFFSET);
-		if ((PresentStateReg & XSDPS_PSR_CARD_INSRT_MASK) == 0x0U) {
-			Status = XST_FAILURE;
-			goto RETURN_PATH;
+	if ((InstancePtr->HC_Version != XSDPS_HC_SPEC_V3) ||
+				((InstancePtr->Host_Caps & XSDPS_CAPS_SLOT_TYPE_MASK)
+				!= XSDPS_CAPS_EMB_SLOT)) {
+		if(InstancePtr->Config.CardDetect != 0U) {
+			/* Check status to ensure card is initialized */
+			PresentStateReg = XSdPs_ReadReg(InstancePtr->Config.BaseAddress,
+					XSDPS_PRES_STATE_OFFSET);
+			if ((PresentStateReg & XSDPS_PSR_CARD_INSRT_MASK) == 0x0U) {
+				Status = XST_FAILURE;
+				goto RETURN_PATH;
+			}
 		}
 	}
 
@@ -1196,20 +1586,26 @@ s32 XSdPs_ReadPolled(XSdPs *InstancePtr, u32 Arg, u32 BlkCnt, u8 *Buff)
 		}
 	}
 
-	XSdPs_SetupADMA2DescTbl(InstancePtr, BlkCnt, Buff);
+	if (InstancePtr->Dma64BitAddr >= ADDRESS_BEYOND_32BIT) {
+		XSdPs_SetupADMA2DescTbl64Bit(InstancePtr, BlkCnt);
+	} else {
+		XSdPs_SetupADMA2DescTbl(InstancePtr, BlkCnt, Buff);
+		if (ucIsCachedMemory( Buff )) {
+			Xil_DCacheInvalidateRange((INTPTR)Buff,
+				BlkCnt * XSDPS_BLK_SIZE_512_MASK);
+		}
+	}
 
-	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
-			XSDPS_XFER_MODE_OFFSET,
-			XSDPS_TM_AUTO_CMD12_EN_MASK |
-			XSDPS_TM_BLK_CNT_EN_MASK | XSDPS_TM_DAT_DIR_SEL_MASK |
-			XSDPS_TM_DMA_EN_MASK | XSDPS_TM_MUL_SIN_BLK_SEL_MASK);
 
 	if( ucIsCachedMemory( ( const uint8_t *)Buff ) != 0 )
 	{
 		Xil_DCacheInvalidateRange( ( unsigned )Buff, BlkCnt * XSDPS_BLK_SIZE_512_MASK);
 	}
+	TransferMode = XSDPS_TM_AUTO_CMD12_EN_MASK |
+		XSDPS_TM_BLK_CNT_EN_MASK | XSDPS_TM_DAT_DIR_SEL_MASK |
+		XSDPS_TM_DMA_EN_MASK | XSDPS_TM_MUL_SIN_BLK_SEL_MASK;
 
-	/* Send block read command */
+	/* Send multiple blocks read command */
 	Status = XSdPs_CmdTransfer(InstancePtr, CMD18, Arg, BlkCnt);
 	if (Status != XST_SUCCESS) {
 		Status = XST_FAILURE;
@@ -1290,10 +1686,14 @@ s32 XSdPs_WritePolled(XSdPs *InstancePtr, u32 Arg, u32 BlkCnt, const u8 *Buff)
 
 	}
 
-	XSdPs_SetupADMA2DescTbl(InstancePtr, BlkCnt, Buff);
-	if( ucIsCachedMemory( ( const uint8_t *)Buff ) != 0 )
-	{
-		Xil_DCacheFlushRange( ( unsigned )Buff, BlkCnt * XSDPS_BLK_SIZE_512_MASK);
+	if (InstancePtr->Dma64BitAddr >= ADDRESS_BEYOND_32BIT) {
+		XSdPs_SetupADMA2DescTbl64Bit(InstancePtr, BlkCnt);
+	} else {
+		XSdPs_SetupADMA2DescTbl(InstancePtr, BlkCnt, Buff);
+		if( ucIsCachedMemory( ( const uint8_t *)Buff ) != 0 ) {
+			Xil_DCacheFlushRange((INTPTR)Buff,
+				BlkCnt * XSDPS_BLK_SIZE_512_MASK);
+		}
 	}
 
 	if( ulSDWritePause != 0ul )
@@ -1318,17 +1718,15 @@ s32 XSdPs_WritePolled(XSdPs *InstancePtr, u32 Arg, u32 BlkCnt, const u8 *Buff)
 	}
 	else
 	{
-	u32 Status = XSdPs_ReadStatus(InstancePtr);
+	/*u32 Status =*/ XSdPs_ReadStatus(InstancePtr);
 //		eventLogAdd("Wt %lx", Status);
 	}
 
-	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
-			XSDPS_XFER_MODE_OFFSET,
-			XSDPS_TM_AUTO_CMD12_EN_MASK |
-			XSDPS_TM_BLK_CNT_EN_MASK |
-			XSDPS_TM_MUL_SIN_BLK_SEL_MASK | XSDPS_TM_DMA_EN_MASK);
+	TransferMode = XSDPS_TM_AUTO_CMD12_EN_MASK |
+		XSDPS_TM_BLK_CNT_EN_MASK |
+		XSDPS_TM_MUL_SIN_BLK_SEL_MASK | XSDPS_TM_DMA_EN_MASK;
 
-	/* Send block write command */
+	/* Send multiple blocks write command */
 	Status = XSdPs_CmdTransfer(InstancePtr, CMD25, Arg, BlkCnt);
 	if (Status != XST_SUCCESS) {
 		Status = XST_FAILURE;
@@ -1358,7 +1756,7 @@ RETURN_PATH:
 ******************************************************************************/
 s32 XSdPs_Select_Card (XSdPs *InstancePtr)
 {
-	s32 Status = 0;
+	s32 Status;
 
 	/* Send CMD7 - Select card */
 	Status = XSdPs_CmdTransfer(InstancePtr, CMD7,
@@ -1371,6 +1769,253 @@ s32 XSdPs_Select_Card (XSdPs *InstancePtr)
 RETURN_PATH:
 		return Status;
 
+}
+
+/*****************************************************************************/
+/**
+*
+* API to setup ADMA2 descriptor table for 64 Bit DMA
+*
+*
+* @param	InstancePtr is a pointer to the XSdPs instance.
+* @param	BlkCnt - block count.
+*
+* @return	None
+*
+* @note		None.
+*
+******************************************************************************/
+void XSdPs_SetupADMA2DescTbl64Bit(XSdPs *InstancePtr, u32 BlkCnt)
+{
+//#ifdef __ICCARM__
+//#pragma data_alignment = 32
+//	static XSdPs_Adma2Descriptor64 Adma2_DescrTbl[32];
+//#else
+//	static XSdPs_Adma2Descriptor64 Adma2_DescrTbl[32] __attribute__ ((aligned(32)));
+//#endif
+	static XSdPs_Adma2Descriptor64 *Adma2_DescrTbl = NULL;
+	u32 TotalDescLines;
+	u64 DescNum;
+	u32 BlkSize;
+
+	if( Adma2_DescrTbl == NULL )
+	{
+		Adma2_DescrTbl = (XSdPs_Adma2Descriptor64 *)pucGetUncachedMemory( 32uL * sizeof *Adma2_DescrTbl );
+		if( Adma2_DescrTbl == NULL )
+		{
+			return;
+		}
+		memset( Adma2_DescrTbl, 0, 32uL * sizeof *Adma2_DescrTbl );
+}
+
+	/* Setup ADMA2 - Write descriptor table and point ADMA SAR to it */
+	BlkSize = (u32)XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+					XSDPS_BLK_SIZE_OFFSET) &
+					XSDPS_BLK_SIZE_MASK;
+
+	if((BlkCnt*BlkSize) < XSDPS_DESC_MAX_LENGTH) {
+
+		TotalDescLines = 1U;
+
+	} else {
+
+		TotalDescLines = ((BlkCnt*BlkSize) / XSDPS_DESC_MAX_LENGTH);
+		if (((BlkCnt * BlkSize) % XSDPS_DESC_MAX_LENGTH) != 0U) {
+			TotalDescLines += 1U;
+		}
+
+	}
+
+	for (DescNum = 0U; DescNum < (TotalDescLines-1); DescNum++) {
+		Adma2_DescrTbl[DescNum].Address =
+				InstancePtr->Dma64BitAddr +
+				(DescNum*XSDPS_DESC_MAX_LENGTH);
+		Adma2_DescrTbl[DescNum].Attribute =
+				XSDPS_DESC_TRAN | XSDPS_DESC_VALID;
+		Adma2_DescrTbl[DescNum].Length = 0U;
+	}
+
+	Adma2_DescrTbl[TotalDescLines-1].Address =
+				InstancePtr->Dma64BitAddr +
+				(DescNum*XSDPS_DESC_MAX_LENGTH);
+
+	Adma2_DescrTbl[TotalDescLines-1].Attribute =
+			XSDPS_DESC_TRAN | XSDPS_DESC_END | XSDPS_DESC_VALID;
+
+	Adma2_DescrTbl[TotalDescLines-1].Length =
+			(u16)((BlkCnt*BlkSize) - (u32)(DescNum*XSDPS_DESC_MAX_LENGTH));
+
+	XSdPs_WriteReg(InstancePtr->Config.BaseAddress, XSDPS_ADMA_SAR_OFFSET,
+			(u32)(UINTPTR)&(Adma2_DescrTbl[0]));
+
+	if (ucIsCachedMemory( (const uint8_t *)Adma2_DescrTbl )) {
+		Xil_DCacheFlushRange((INTPTR)&(Adma2_DescrTbl[0]),
+			sizeof(XSdPs_Adma2Descriptor64) * 32U);
+	}
+
+	/* Clear the 64-Bit Address variable */
+	InstancePtr->Dma64BitAddr = 0U;
+
+}
+
+/*****************************************************************************/
+/**
+*
+* API to setup ADMA2 descriptor table for 32-bit DMA
+*
+*
+* @param	InstancePtr is a pointer to the XSdPs instance.
+* @param	BlkCnt - block count.
+* @param	Buff pointer to data buffer.
+*
+* @return	None
+*
+* @note		None.
+*
+******************************************************************************/
+static void XSdPs_Setup32ADMA2DescTbl(XSdPs *InstancePtr, u32 BlkCnt, const u8 *Buff)
+{
+//#ifdef __ICCARM__
+//#pragma data_alignment = 32
+//	static XSdPs_Adma2Descriptor32 Adma2_DescrTbl[32];
+//#else
+//	static XSdPs_Adma2Descriptor32 Adma2_DescrTbl[32] __attribute__ ((aligned(32)));
+//#endif
+	static XSdPs_Adma2Descriptor32 *Adma2_DescrTbl = NULL;
+	u32 TotalDescLines;
+	u64 DescNum;
+	u32 BlkSize;
+
+	if( Adma2_DescrTbl == NULL )
+	{
+		Adma2_DescrTbl = (XSdPs_Adma2Descriptor32 *)pucGetUncachedMemory( 32uL * sizeof *Adma2_DescrTbl );
+		if( Adma2_DescrTbl == NULL )
+		{
+			return;
+		}
+		memset( Adma2_DescrTbl, 0, 32uL * sizeof *Adma2_DescrTbl );
+	}
+
+	/* Setup ADMA2 - Write descriptor table and point ADMA SAR to it */
+	BlkSize = (u32)XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+					XSDPS_BLK_SIZE_OFFSET) &
+					XSDPS_BLK_SIZE_MASK;
+
+	if((BlkCnt*BlkSize) < XSDPS_DESC_MAX_LENGTH) {
+		TotalDescLines = 1U;
+	} else {
+		TotalDescLines = ((BlkCnt*BlkSize) / XSDPS_DESC_MAX_LENGTH);
+		if (((BlkCnt * BlkSize) % XSDPS_DESC_MAX_LENGTH) != 0U) {
+			TotalDescLines += 1U;
+		}
+	}
+
+	for (DescNum = 0U; DescNum < (TotalDescLines-1); DescNum++) {
+		Adma2_DescrTbl[DescNum].Address =
+				(u32)((UINTPTR)Buff + (DescNum*XSDPS_DESC_MAX_LENGTH));
+		Adma2_DescrTbl[DescNum].Attribute =
+				XSDPS_DESC_TRAN | XSDPS_DESC_VALID;
+		Adma2_DescrTbl[DescNum].Length = 0U;
+	}
+
+	Adma2_DescrTbl[TotalDescLines-1].Address =
+			(u32)((UINTPTR)Buff + (DescNum*XSDPS_DESC_MAX_LENGTH));
+
+	Adma2_DescrTbl[TotalDescLines-1].Attribute =
+			XSDPS_DESC_TRAN | XSDPS_DESC_END | XSDPS_DESC_VALID;
+
+	Adma2_DescrTbl[TotalDescLines-1].Length =
+			(u16)((BlkCnt*BlkSize) - (u32)(DescNum*XSDPS_DESC_MAX_LENGTH));
+
+	XSdPs_WriteReg(InstancePtr->Config.BaseAddress, XSDPS_ADMA_SAR_OFFSET,
+			(u32)(UINTPTR)&(Adma2_DescrTbl[0]));
+
+	if (ucIsCachedMemory( (const uint8_t *)Adma2_DescrTbl )) {
+		Xil_DCacheFlushRange((INTPTR)&(Adma2_DescrTbl[0]),
+			sizeof(XSdPs_Adma2Descriptor32) * 32U);
+	}
+}
+
+/*****************************************************************************/
+/**
+*
+* API to setup ADMA2 descriptor table for 64-bit DMA
+*
+*
+* @param	InstancePtr is a pointer to the XSdPs instance.
+* @param	BlkCnt - block count.
+* @param	Buff pointer to data buffer.
+*
+* @return	None
+*
+* @note		None.
+*
+******************************************************************************/
+static void XSdPs_Setup64ADMA2DescTbl(XSdPs *InstancePtr, u32 BlkCnt, const u8 *Buff)
+{
+//#ifdef __ICCARM__
+//#pragma data_alignment = 32
+//	static XSdPs_Adma2Descriptor64 Adma2_DescrTbl[32];
+//#else
+//	static XSdPs_Adma2Descriptor64 Adma2_DescrTbl[32] __attribute__ ((aligned(32)));
+//#endif
+	static XSdPs_Adma2Descriptor64 *Adma2_DescrTbl = NULL;
+	u32 TotalDescLines;
+	u64 DescNum;
+	u32 BlkSize;
+
+	if( Adma2_DescrTbl == NULL )
+	{
+		Adma2_DescrTbl = (XSdPs_Adma2Descriptor64 *)pucGetUncachedMemory( 32uL * sizeof *Adma2_DescrTbl );
+		if( Adma2_DescrTbl == NULL )
+		{
+			return;
+		}
+		memset( Adma2_DescrTbl, 0, 32uL * sizeof *Adma2_DescrTbl );
+	}
+	/* Setup ADMA2 - Write descriptor table and point ADMA SAR to it */
+	BlkSize = (u32)XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+					XSDPS_BLK_SIZE_OFFSET) &
+					XSDPS_BLK_SIZE_MASK;
+
+	if((BlkCnt*BlkSize) < XSDPS_DESC_MAX_LENGTH) {
+		TotalDescLines = 1U;
+	} else {
+		TotalDescLines = ((BlkCnt*BlkSize) / XSDPS_DESC_MAX_LENGTH);
+		if (((BlkCnt * BlkSize) % XSDPS_DESC_MAX_LENGTH) != 0U) {
+			TotalDescLines += 1U;
+		}
+	}
+
+	for (DescNum = 0U; DescNum < (TotalDescLines-1); DescNum++) {
+		Adma2_DescrTbl[DescNum].Address =
+				((UINTPTR)Buff + (DescNum*XSDPS_DESC_MAX_LENGTH));
+		Adma2_DescrTbl[DescNum].Attribute =
+				XSDPS_DESC_TRAN | XSDPS_DESC_VALID;
+		Adma2_DescrTbl[DescNum].Length = 0U;
+	}
+
+	Adma2_DescrTbl[TotalDescLines-1].Address =
+			(u64)((UINTPTR)Buff + (DescNum*XSDPS_DESC_MAX_LENGTH));
+
+	Adma2_DescrTbl[TotalDescLines-1].Attribute =
+			XSDPS_DESC_TRAN | XSDPS_DESC_END | XSDPS_DESC_VALID;
+
+	Adma2_DescrTbl[TotalDescLines-1].Length =
+			(u16)((BlkCnt*BlkSize) - (u32)(DescNum*XSDPS_DESC_MAX_LENGTH));
+
+#if defined(__aarch64__) || defined(__arch64__)
+	XSdPs_WriteReg(InstancePtr->Config.BaseAddress, XSDPS_ADMA_SAR_EXT_OFFSET,
+			(u32)((UINTPTR)(Adma2_DescrTbl)>>32U));
+#endif
+
+	XSdPs_WriteReg(InstancePtr->Config.BaseAddress, XSDPS_ADMA_SAR_OFFSET,
+			(u32)(UINTPTR)&(Adma2_DescrTbl[0]));
+
+	if (ucIsCachedMemory( (const uint8_t *)Adma2_DescrTbl )) {
+		Xil_DCacheFlushRange((INTPTR)&(Adma2_DescrTbl[0]),
+			sizeof(XSdPs_Adma2Descriptor64) * 32U);
+	}
 }
 
 /*****************************************************************************/
@@ -1390,55 +2035,10 @@ RETURN_PATH:
 ******************************************************************************/
 void XSdPs_SetupADMA2DescTbl(XSdPs *InstancePtr, u32 BlkCnt, const u8 *Buff)
 {
-	u32 TotalDescLines = 0U;
-	u32 DescNum = 0U;
-	u32 BlkSize = 0U;
-
-	/* Setup ADMA2 - Write descriptor table and point ADMA SAR to it */
-	BlkSize = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
-					XSDPS_BLK_SIZE_OFFSET);
-	BlkSize = BlkSize & XSDPS_BLK_SIZE_MASK;
-
-	if((BlkCnt*BlkSize) < XSDPS_DESC_MAX_LENGTH) {
-
-		TotalDescLines = 1U;
-
-	}else {
-
-		TotalDescLines = ((BlkCnt*BlkSize) / XSDPS_DESC_MAX_LENGTH);
-		if (((BlkCnt * BlkSize) % XSDPS_DESC_MAX_LENGTH) != 0U) {
-			TotalDescLines += 1U;
-		}
-
-	}
-
-	for (DescNum = 0U; DescNum < (TotalDescLines-1); DescNum++) {
-		InstancePtr->Adma2_DescrTbl[DescNum].Address =
-				(u32)(Buff + (DescNum*XSDPS_DESC_MAX_LENGTH));
-		InstancePtr->Adma2_DescrTbl[DescNum].Attribute =
-				XSDPS_DESC_TRAN | XSDPS_DESC_VALID;
-		/* This will write '0' to length field which indicates 65536 */
-		InstancePtr->Adma2_DescrTbl[DescNum].Length =
-				(u16)XSDPS_DESC_MAX_LENGTH;
-	}
-
-	InstancePtr->Adma2_DescrTbl[TotalDescLines-1].Address =
-			(u32)(Buff + (DescNum*XSDPS_DESC_MAX_LENGTH));
-
-	InstancePtr->Adma2_DescrTbl[TotalDescLines-1].Attribute =
-			XSDPS_DESC_TRAN | XSDPS_DESC_END | XSDPS_DESC_VALID;
-
-	InstancePtr->Adma2_DescrTbl[TotalDescLines-1].Length =
-			(BlkCnt*BlkSize) - (DescNum*XSDPS_DESC_MAX_LENGTH);
-
-
-	XSdPs_WriteReg(InstancePtr->Config.BaseAddress, XSDPS_ADMA_SAR_OFFSET,
-			(u32)&(InstancePtr->Adma2_DescrTbl[0]));
-
-	if( ucIsCachedMemory( ( const uint8_t *)InstancePtr->Adma2_DescrTbl ) != 0 )
-	{
-		Xil_DCacheFlushRange( ( unsigned ) &( InstancePtr->Adma2_DescrTbl[ 0 ] ),
-			sizeof(XSdPs_Adma2Descriptor) * 32);
+	if (InstancePtr->HC_Version == XSDPS_HC_SPEC_V3) {
+		XSdPs_Setup64ADMA2DescTbl(InstancePtr, BlkCnt, Buff);
+	} else {
+		XSdPs_Setup32ADMA2DescTbl(InstancePtr, BlkCnt, Buff);
 	}
 }
 
@@ -1471,20 +2071,25 @@ s32 XSdPs_MmcCardInitialize(XSdPs *InstancePtr)
 	s32 Status;
 	u32 RespOCR;
 	u32 CSD[4];
+	u32 BlkLen, DeviceSize, Mult;
 
 	Xil_AssertNonvoid(InstancePtr != NULL);
 	Xil_AssertNonvoid(InstancePtr->IsReady == XIL_COMPONENT_IS_READY);
 
-	if(InstancePtr->Config.CardDetect != 0U) {
-		/*
-		 * Check the present state register to make sure
-		 * card is inserted and detected by host controller
-		 */
-		PresentStateReg = XSdPs_ReadReg(InstancePtr->Config.BaseAddress,
-				XSDPS_PRES_STATE_OFFSET);
-		if ((PresentStateReg & XSDPS_PSR_CARD_INSRT_MASK) == 0U)	{
-			Status = XST_FAILURE;
-			goto RETURN_PATH;
+	if ((InstancePtr->HC_Version != XSDPS_HC_SPEC_V3) ||
+				((InstancePtr->Host_Caps & XSDPS_CAPS_SLOT_TYPE_MASK)
+				!= XSDPS_CAPS_EMB_SLOT)) {
+		if(InstancePtr->Config.CardDetect != 0U) {
+			/*
+			 * Check the present state register to make sure
+			 * card is inserted and detected by host controller
+			 */
+			PresentStateReg = XSdPs_ReadReg(InstancePtr->Config.BaseAddress,
+					XSDPS_PRES_STATE_OFFSET);
+			if ((PresentStateReg & XSDPS_PSR_CARD_INSRT_MASK) == 0U)	{
+				Status = XST_FAILURE;
+				goto RETURN_PATH;
+			}
 		}
 	}
 
@@ -1546,7 +2151,6 @@ s32 XSdPs_MmcCardInitialize(XSdPs *InstancePtr)
 		goto RETURN_PATH;
 	}
 
-	/* Read Card specific data. */
 	Status = XSdPs_CmdTransfer(InstancePtr, CMD9, (InstancePtr->RelCardAddr), 0U);
 	if (Status != XST_SUCCESS) {
 		Status = XST_FAILURE;
@@ -1566,12 +2170,94 @@ s32 XSdPs_MmcCardInitialize(XSdPs *InstancePtr)
 	CSD[3] = XSdPs_ReadReg(InstancePtr->Config.BaseAddress,
 			XSDPS_RESP3_OFFSET);
 
-	( void ) CSD[0];
+	InstancePtr->Card_Version =  (u8)((u32)(CSD[3] & CSD_SPEC_VER_MASK) >>18U);
+
+	/* Calculating the memory capacity */
+	BlkLen = 1U << ((u32)(CSD[2] & READ_BLK_LEN_MASK) >> 8U);
+	Mult = 1U << ((u32)((CSD[1] & C_SIZE_MULT_MASK) >> 7U) + 2U);
+	DeviceSize = (CSD[1] & C_SIZE_LOWER_MASK) >> 22U;
+	DeviceSize |= (CSD[2] & C_SIZE_UPPER_MASK) << 10U;
+	DeviceSize = (DeviceSize + 1U) * Mult;
+	DeviceSize =  DeviceSize * BlkLen;
+
+	InstancePtr->SectorCount = (DeviceSize/XSDPS_BLK_SIZE_512_MASK);
 
 	Status = XST_SUCCESS;
 
 RETURN_PATH:
 	return Status;
 
+}
+
+/*****************************************************************************/
+/**
+*
+* API to idle the SDIO Interface
+*
+*
+* @param	InstancePtr is a pointer to the XSdPs instance.
+*
+* @return	None
+*
+* @note		None.
+*
+******************************************************************************/
+void XSdPs_Idle(XSdPs *InstancePtr)
+{
+	u32 Timeout = MAX_TIMEOUT;
+	u32 PresentStateReg;
+	u32 StatusReg;
+	u8 RegVal;
+
+	PresentStateReg = XSdPs_ReadReg8(InstancePtr->Config.BaseAddress,
+			XSDPS_PRES_STATE_OFFSET);
+	/* Check for Card Present */
+	if ((PresentStateReg & XSDPS_PSR_CARD_INSRT_MASK) != 0U) {
+		/* Check for SD idle */
+		do {
+			StatusReg = XSdPs_ReadReg8(InstancePtr->Config.BaseAddress,
+					XSDPS_PRES_STATE_OFFSET);
+			Timeout = Timeout - 1;
+		} while (((StatusReg & (XSDPS_PSR_INHIBIT_CMD_MASK
+				| XSDPS_PSR_INHIBIT_DAT_MASK
+				| XSDPS_PSR_DAT_ACTIVE_MASK)) != 0U)
+				&& (Timeout != 0U));
+	}
+	/* Reset the eMMC card */
+	if (InstancePtr->CardType == XSDPS_CHIP_EMMC) {
+		RegVal = XSdPs_ReadReg8(InstancePtr->Config.BaseAddress,
+				XSDPS_POWER_CTRL_OFFSET);
+		XSdPs_WriteReg8(InstancePtr->Config.BaseAddress,
+				XSDPS_POWER_CTRL_OFFSET,
+				RegVal | XSDPS_PC_EMMC_HW_RST_MASK);
+		usleep(1000);
+		RegVal = XSdPs_ReadReg8(InstancePtr->Config.BaseAddress,
+				XSDPS_POWER_CTRL_OFFSET);
+		XSdPs_WriteReg8(InstancePtr->Config.BaseAddress,
+				XSDPS_POWER_CTRL_OFFSET,
+				RegVal & ~XSDPS_PC_EMMC_HW_RST_MASK);
+	}
+
+	/* Disable bus power */
+	XSdPs_WriteReg8(InstancePtr->Config.BaseAddress,
+			XSDPS_POWER_CTRL_OFFSET, 0);
+
+	/* Delay to disable bus power to card */
+	(void)usleep(1000U);
+
+	/* "Software reset for all" is initiated */
+	XSdPs_WriteReg8(InstancePtr->Config.BaseAddress,
+			XSDPS_SW_RST_OFFSET, XSDPS_SWRST_ALL_MASK);
+
+	Timeout = MAX_TIMEOUT;
+	/* Proceed with initialization only after reset is complete */
+	RegVal = XSdPs_ReadReg8(InstancePtr->Config.BaseAddress,
+			XSDPS_SW_RST_OFFSET);
+	Timeout = Timeout - 1;
+	while (((RegVal & XSDPS_SWRST_ALL_MASK) != 0U) && (Timeout != 0U)) {
+		RegVal = XSdPs_ReadReg8(InstancePtr->Config.BaseAddress,
+				XSDPS_SW_RST_OFFSET);
+		Timeout = Timeout - 1;
+	}
 }
 /** @} */

--- a/portable/Zynq.2019.3/xsdps.h
+++ b/portable/Zynq.2019.3/xsdps.h
@@ -1,0 +1,282 @@
+/******************************************************************************
+*
+* Copyright (C) 2013 - 2019 Xilinx, Inc.  All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*
+*
+*
+******************************************************************************/
+/*****************************************************************************/
+/**
+*
+* @file xsdps.h
+* @addtogroup sdps_v3_8
+* @{
+* @details
+*
+* This file contains the implementation of XSdPs driver.
+* This driver is used initialize read from and write to the SD card.
+* Features such as switching bus width to 4-bit and switching to high speed,
+* changing clock frequency, block size etc. are supported.
+* SD 2.0 uses 1/4 bus width and speeds of 25/50KHz. Initialization, however
+* is done using 1-bit bus width and 400KHz clock frequency.
+* SD commands are classified as broadcast and addressed. Commands can be
+* those with response only (using only command line) or
+* response + data (using command and data lines).
+* Only one command can be sent at a time. During a data transfer however,
+* when dsta lines are in use, certain commands (which use only the command
+* line) can be sent, most often to obtain status.
+* This driver does not support multi card slots at present.
+*
+* Initialization:
+* This includes initialization on the host controller side to select
+* clock frequency, bus power and default transfer related parameters.
+* The default voltage is 3.3V.
+* On the SD card side, the initialization and identification state diagram is
+* implemented. This resets the card, gives it a unique address/ID and
+* identifies key card related specifications.
+*
+* Data transfer:
+* The SD card is put in transfer state to read from or write to it.
+* The default block size is 512 bytes and if supported,
+* default bus width is 4-bit and bus speed is High speed.
+* The read and write functions are implemented in polled mode using ADMA2.
+*
+* At any point, when key parameters such as block size or
+* clock/speed or bus width are modified, this driver takes care of
+* maintaining the same selection on host and card.
+* All error bits in host controller are monitored by the driver and in the
+* event one of them is set, driver will clear the interrupt status and
+* communicate failure to the upper layer.
+*
+* File system use:
+* This driver can be used with xilffs library to read and write files to SD.
+* (Please refer to procedure in diskio.c). The file system read/write example
+* in polled mode can used for reference.
+*
+* There is no example for using SD driver without file system at present.
+* However, the driver can be used without the file system. The glue layer
+* in filesystem can be used as reference for the same. The block count
+* passed to the read/write function in one call is limited by the ADMA2
+* descriptor table and hence care will have to be taken to call read/write
+* API's in a loop for large file sizes.
+*
+* Interrupt mode is not supported because it offers no improvement when used
+* with file system.
+*
+* eMMC support:
+* SD driver supports SD and eMMC based on the "enable MMC" parameter in SDK.
+* The features of eMMC supported by the driver will depend on those supported
+* by the host controller. The current driver supports read/write on eMMC card
+* using 4-bit and high speed mode currently.
+*
+* Features not supported include - card write protect, password setting,
+* lock/unlock, interrupts, SDMA mode, programmed I/O mode and
+* 64-bit addressed ADMA2, erase/pre-erase commands.
+*
+* <pre>
+* MODIFICATION HISTORY:
+*
+* Ver   Who    Date     Changes
+* ----- ---    -------- -----------------------------------------------
+* 1.00a hk/sg  10/17/13 Initial release
+* 2.0   hk      03/07/14 Version number revised.
+* 2.1   hk     04/18/14 Increase sleep for eMMC switch command.
+*                       Add sleep for microblaze designs. CR# 781117.
+* 2.2   hk     07/28/14 Make changes to enable use of data cache.
+* 2.3   sk     09/23/14 Send command for relative card address
+*                       when re-initialization is done.CR# 819614.
+*						Use XSdPs_Change_ClkFreq API whenever changing
+*						clock.CR# 816586.
+* 2.4	sk	   12/04/14 Added support for micro SD without
+* 						WP/CD. CR# 810655.
+*						Checked for DAT Inhibit mask instead of CMD
+* 						Inhibit mask in Cmd Transfer API.
+*						Added Support for SD Card v1.0
+* 2.5 	sg		07/09/15 Added SD 3.0 features
+*       kvn     07/15/15 Modified the code according to MISRAC-2012.
+* 2.6   sk     10/12/15 Added support for SD card v1.0 CR# 840601.
+* 2.7   sk     11/24/15 Considered the slot type befoe checking CD/WP pins.
+*       sk     12/10/15 Added support for MMC cards.
+*              01/08/16 Added workaround for issue in auto tuning mode
+*                       of SDR50, SDR104 and HS200.
+*       sk     02/16/16 Corrected the Tuning logic.
+*       sk     03/01/16 Removed Bus Width check for eMMC. CR# 938311.
+* 2.8   sk     04/20/16 Added new workaround for auto tuning.
+*              05/03/16 Standard Speed for SD to 19MHz in ZynqMPSoC. CR#951024
+* 3.0   sk     06/09/16 Added support for mkfs to calculate sector count.
+*       sk     07/16/16 Added support for UHS modes.
+*       sk     07/07/16 Used usleep API for both arm and microblaze.
+*       sk     07/16/16 Added Tap delays accordingly to different SD/eMMC
+*                       operating modes.
+*       sk     08/13/16 Removed sleep.h from xsdps.h as a temporary fix for
+*                       CR#956899.
+* 3.1   mi     09/07/16 Removed compilation warnings with extra compiler flags.
+*       sk     10/13/16 Reduced the delay during power cycle to 1ms as per spec
+*       sk     10/19/16 Used emmc_hwreset pin to reset eMMC.
+*       sk     11/07/16 Enable Rst_n bit in ext_csd reg if not enabled.
+*       sk     11/16/16 Issue DLL reset at 31 iteration to load new zero value.
+* 3.2   sk     11/30/16 Modified the voltage switching sequence as per spec.
+*       sk     02/01/17 Added HSD and DDR mode support for eMMC.
+*       sk     02/01/17 Consider bus width parameter from design for switching
+*       vns    02/09/17 Added ARMA53_32 support for ZynqMP CR#968397
+*       sk     03/20/17 Add support for EL1 non-secure mode.
+* 3.3   mn     05/17/17 Add support for 64bit DMA addressing
+* 	mn     08/07/17 Modify driver to support 64-bit DMA in arm64 only
+*       mn     08/17/17 Enabled CCI support for A53 by adding cache coherency
+*                       information.
+*       mn     09/06/17 Resolved compilation errors with IAR toolchain
+* 3.6   mn     08/01/18 Add support for using 64Bit DMA with 32-Bit Processor
+* 3.7   mn     02/01/19 Add support for idling of SDIO
+* 3.8   mn     04/12/19 Modified TapDelay code for supporting ZynqMP and Versal
+*       mn     09/17/19 Modified ADMA handling API for 32bit and 64bit addresses
+*
+* </pre>
+*
+******************************************************************************/
+
+
+#ifndef SDPS_H_
+#define SDPS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "xil_printf.h"
+#include "xil_cache.h"
+#include "xstatus.h"
+#include "xsdps_hw.h"
+#include "xplatform_info.h"
+#include <string.h>
+
+/************************** Constant Definitions *****************************/
+
+#define XSDPS_CT_ERROR	0x2L	/**< Command timeout flag */
+#define MAX_TUNING_COUNT	40U		/**< Maximum Tuning count */
+#define MAX_TIMEOUT		0x1FFFFFFFU		/**< Maximum Timeout */
+
+/**************************** Type Definitions *******************************/
+
+typedef void (*XSdPs_ConfigTap) (u32 Bank, u32 DeviceId, u32 CardType);
+
+/**
+ * This typedef contains configuration information for the device.
+ */
+typedef struct {
+	u16 DeviceId;			/**< Unique ID  of device */
+	u32 BaseAddress;		/**< Base address of the device */
+	u32 InputClockHz;		/**< Input clock frequency */
+	u32 CardDetect;			/**< Card Detect */
+	u32 WriteProtect;			/**< Write Protect */
+	u32 BusWidth;			/**< Bus Width */
+	u32 BankNumber;			/**< MIO Bank selection for SD */
+	u32 HasEMIO;			/**< If SD is connected to EMIO */
+	u8 IsCacheCoherent; 		/**< If SD is Cache Coherent or not */
+} XSdPs_Config;
+
+/* ADMA2 32-Bit descriptor table */
+typedef struct {
+	u16 Attribute;		/**< Attributes of descriptor */
+	u16 Length;		/**< Length of current dma transfer */
+	u32 Address;		/**< Address of current dma transfer */
+#ifdef __ICCARM__
+#pragma data_alignment = 32
+} XSdPs_Adma2Descriptor32;
+#else
+}  __attribute__((__packed__))XSdPs_Adma2Descriptor32;
+#endif
+
+/* ADMA2 64-Bit descriptor table */
+typedef struct {
+	u16 Attribute;		/**< Attributes of descriptor */
+	u16 Length;		/**< Length of current dma transfer */
+	u64 Address;		/**< Address of current dma transfer */
+#ifdef __ICCARM__
+#pragma data_alignment = 32
+} XSdPs_Adma2Descriptor64;
+#else
+}  __attribute__((__packed__))XSdPs_Adma2Descriptor64;
+#endif
+
+/**
+ * The XSdPs driver instance data. The user is required to allocate a
+ * variable of this type for every SD device in the system. A pointer
+ * to a variable of this type is then passed to the driver API functions.
+ */
+typedef struct {
+	XSdPs_Config Config;	/**< Configuration structure */
+	u32 IsReady;		/**< Device is initialized and ready */
+	u32 Host_Caps;		/**< Capabilities of host controller */
+	u32 Host_CapsExt;	/**< Extended Capabilities */
+	u32 HCS;		/**< High capacity support in card */
+	u8  CardType;		/**< Type of card - SD/MMC/eMMC */
+	u8  Card_Version;	/**< Card version */
+	u8  HC_Version;		/**< Host controller version */
+	u8  BusWidth;		/**< Current operating bus width */
+	u32 BusSpeed;		/**< Current operating bus speed */
+	u8  Switch1v8;		/**< 1.8V Switch support */
+	u32 CardID[4];		/**< Card ID Register */
+	u32 RelCardAddr;	/**< Relative Card Address */
+	u32 CardSpecData[4];	/**< Card Specific Data Register */
+	u32 SectorCount;		/**< Sector Count */
+	u32 SdCardConfig;	/**< Sd Card Configuration Register */
+	u32 Mode;			/**< Bus Speed Mode */
+	u32	OTapDelay;		/**< Output Tap Delay */
+	u32	ITapDelay;		/**< Input Tap Delay */
+	u64 Dma64BitAddr;	/**< 64 Bit DMA Address */
+} XSdPs;
+
+/***************** Macros (Inline Functions) Definitions *********************/
+
+/************************** Function Prototypes ******************************/
+XSdPs_Config *XSdPs_LookupConfig(u16 DeviceId);
+s32 XSdPs_CfgInitialize(XSdPs *InstancePtr, XSdPs_Config *ConfigPtr,
+				u32 EffectiveAddr);
+s32 XSdPs_SdCardInitialize(XSdPs *InstancePtr);
+s32 XSdPs_ReadPolled(XSdPs *InstancePtr, u32 Arg, u32 BlkCnt, u8 *Buff);
+s32 XSdPs_WritePolled(XSdPs *InstancePtr, u32 Arg, u32 BlkCnt, const u8 *Buff);
+s32 XSdPs_SetBlkSize(XSdPs *InstancePtr, u16 BlkSize);
+s32 XSdPs_Select_Card (XSdPs *InstancePtr);
+s32 XSdPs_Change_ClkFreq(XSdPs *InstancePtr, u32 SelFreq);
+s32 XSdPs_Change_BusWidth(XSdPs *InstancePtr);
+s32 XSdPs_Change_BusSpeed(XSdPs *InstancePtr);
+s32 XSdPs_Get_BusWidth(XSdPs *InstancePtr, u8 *ReadBuff);
+s32 XSdPs_Get_BusSpeed(XSdPs *InstancePtr, u8 *ReadBuff);
+s32 XSdPs_Get_Status(XSdPs *InstancePtr, u8 *SdStatReg);
+s32 XSdPs_Pullup(XSdPs *InstancePtr);
+s32 XSdPs_MmcCardInitialize(XSdPs *InstancePtr);
+s32 XSdPs_CardInitialize(XSdPs *InstancePtr);
+s32 XSdPs_Get_Mmc_ExtCsd(XSdPs *InstancePtr, u8 *ReadBuff);
+s32 XSdPs_Set_Mmc_ExtCsd(XSdPs *InstancePtr, u32 Arg);
+void XSdPs_Idle(XSdPs *InstancePtr);
+#if defined (ARMR5) || defined (__aarch64__) || defined (ARMA53_32) || defined (__MICROBLAZE__)
+void XSdPs_Identify_UhsMode(XSdPs *InstancePtr, u8 *ReadBuff);
+void XSdPs_ddr50_tapdelay(u32 Bank, u32 DeviceId, u32 CardType);
+void XSdPs_hsd_sdr25_tapdelay(u32 Bank, u32 DeviceId, u32 CardType);
+void XSdPs_sdr104_hs200_tapdelay(u32 Bank, u32 DeviceId, u32 CardType);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SD_H_ */
+/** @} */

--- a/portable/Zynq.2019.3/xsdps_g.c
+++ b/portable/Zynq.2019.3/xsdps_g.c
@@ -1,0 +1,77 @@
+/******************************************************************************
+*
+* Copyright (C) 2013 - 2019 Xilinx, Inc.  All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*
+*
+*
+******************************************************************************/
+/*****************************************************************************/
+/**
+*
+* @file xsdps_g.c
+* @addtogroup sdps_v3_8
+* @{
+*
+* This file contains a configuration table that specifies the configuration of
+* SD devices in the system.
+*
+* <pre>
+* MODIFICATION HISTORY:
+*
+* Ver   Who    Date     Changes
+* ----- ---    -------- -----------------------------------------------
+* 1.00a hk/sg  10/17/13 Initial release
+* 3.6   mn     07/06/18 Add initialization macros in sdps
+*       mn     07/13/18 Add initializer macro for HasEMIO
+*
+* </pre>
+*
+******************************************************************************/
+
+
+
+#include "xparameters.h"
+#include "xsdps.h"
+
+/*
+* The configuration table for devices
+*/
+
+#define XPAR_XSDPS_0_BUS_WIDTH			0	// XSDPS_4_BIT_WIDTH
+#define XPAR_XSDPS_0_MIO_BANK			0
+#define XPAR_XSDPS_0_HAS_EMIO			0
+#define XPAR_XSDPS_0_IS_CACHE_COHERENT	1	// 0 Tables are located in uncached memory
+
+XSdPs_Config XSdPs_ConfigTable[] =
+{
+	{
+		XPAR_XSDPS_0_DEVICE_ID,
+		XPAR_XSDPS_0_BASEADDR,
+		XPAR_XSDPS_0_SDIO_CLK_FREQ_HZ,
+		XPAR_XSDPS_0_HAS_CD,
+		XPAR_XSDPS_0_HAS_WP,
+		XPAR_XSDPS_0_BUS_WIDTH,
+		XPAR_XSDPS_0_MIO_BANK,
+		XPAR_XSDPS_0_HAS_EMIO,
+		XPAR_XSDPS_0_IS_CACHE_COHERENT
+	}
+};
+/** @} */

--- a/portable/Zynq.2019.3/xsdps_hw.h
+++ b/portable/Zynq.2019.3/xsdps_hw.h
@@ -1,0 +1,1319 @@
+/******************************************************************************
+*
+* Copyright (C) 2013 - 2019 Xilinx, Inc.  All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*
+*
+*
+******************************************************************************/
+/*****************************************************************************/
+/**
+*
+* @file xsdps_hw.h
+* @addtogroup sdps_v3_8
+* @{
+*
+* This header file contains the identifiers and basic HW access driver
+* functions (or  macros) that can be used to access the device. Other driver
+* functions are defined in xsdps.h.
+*
+* <pre>
+* MODIFICATION HISTORY:
+*
+* Ver   Who    Date     Changes
+* ----- ---    -------- -----------------------------------------------
+* 1.00a hk/sg  10/17/13 Initial release
+* 2.5 	sg	   07/09/15 Added SD 3.0 features
+*       kvn    07/15/15 Modified the code according to MISRAC-2012.
+* 2.7   sk     12/10/15 Added support for MMC cards.
+*       sk     03/02/16 Configured the Tap Delay values for eMMC HS200 mode.
+* 2.8   sk     04/20/16 Added new workaround for auto tuning.
+* 3.0   sk     06/09/16 Added support for mkfs to calculate sector count.
+*       sk     07/16/16 Added support for UHS modes.
+*       sk     07/16/16 Added Tap delays accordingly to different SD/eMMC
+*                       operating modes.
+* 3.1   sk     11/07/16 Enable Rst_n bit in ext_csd reg if not enabled.
+* 3.2   sk     03/20/17 Add support for EL1 non-secure mode.
+* 3.3   mn     08/22/17 Updated for Word Access System support
+*       mn     09/06/17 Added support for ARMCC toolchain
+* 3.4   mn     01/22/18 Separated out SDR104 and HS200 clock defines
+* 3.6   mn     07/06/18 Fix Doxygen warnings for sdps driver
+* 3.8   mn     04/12/19 Modified TapDelay code for supporting ZynqMP and Versal
+*       mn     05/21/19 Set correct tap delays for Versal
+*       mn     05/21/19 Disable DLL Reset code for Versal
+*       mn     05/21/19 Enable SD UHS Mode support by default for Versal
+*       mn     07/03/19 Update Input Tap Delays for Versal
+*
+* </pre>
+*
+******************************************************************************/
+
+#ifndef SD_HW_H_
+#define SD_HW_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************** Include Files *********************************/
+
+#include "xil_types.h"
+#include "xil_assert.h"
+#include "xil_io.h"
+#include "xparameters.h"
+
+/************************** Constant Definitions *****************************/
+
+/* Enable UHS Mode support by default for Versal */
+#ifdef versal
+#define UHS_MODE_ENABLE
+#endif
+/** @name Register Map
+ *
+ * Register offsets from the base address of an SD device.
+ * @{
+ */
+
+#define XSDPS_SDMA_SYS_ADDR_OFFSET	0x00U	/**< SDMA System Address
+							Register */
+#define XSDPS_SDMA_SYS_ADDR_LO_OFFSET	XSDPS_SDMA_SYS_ADDR_OFFSET
+						/**< SDMA System Address
+							Low Register */
+#define XSDPS_ARGMT2_LO_OFFSET		0x00U	/**< Argument2 Low Register */
+#define XSDPS_SDMA_SYS_ADDR_HI_OFFSET	0x02U	/**< SDMA System Address
+							High Register */
+#define XSDPS_ARGMT2_HI_OFFSET		0x02U	/**< Argument2 High Register */
+
+#define XSDPS_BLK_SIZE_OFFSET		0x04U	/**< Block Size Register */
+#define XSDPS_BLK_CNT_OFFSET		0x06U	/**< Block Count Register */
+#define XSDPS_ARGMT_OFFSET		0x08U	/**< Argument Register */
+#define XSDPS_ARGMT1_LO_OFFSET		XSDPS_ARGMT_OFFSET
+						/**< Argument1 Register */
+#define XSDPS_ARGMT1_HI_OFFSET		0x0AU	/**< Argument1 Register */
+
+#define XSDPS_XFER_MODE_OFFSET		0x0CU	/**< Transfer Mode Register */
+#define XSDPS_CMD_OFFSET		0x0EU	/**< Command Register */
+#define XSDPS_RESP0_OFFSET		0x10U	/**< Response0 Register */
+#define XSDPS_RESP1_OFFSET		0x14U	/**< Response1 Register */
+#define XSDPS_RESP2_OFFSET		0x18U	/**< Response2 Register */
+#define XSDPS_RESP3_OFFSET		0x1CU	/**< Response3 Register */
+#define XSDPS_BUF_DAT_PORT_OFFSET	0x20U	/**< Buffer Data Port */
+#define XSDPS_PRES_STATE_OFFSET		0x24U	/**< Present State */
+#define XSDPS_HOST_CTRL1_OFFSET		0x28U	/**< Host Control 1 */
+#define XSDPS_POWER_CTRL_OFFSET		0x29U	/**< Power Control */
+#define XSDPS_BLK_GAP_CTRL_OFFSET	0x2AU	/**< Block Gap Control */
+#define XSDPS_WAKE_UP_CTRL_OFFSET	0x2BU	/**< Wake Up Control */
+#define XSDPS_CLK_CTRL_OFFSET		0x2CU	/**< Clock Control */
+#define XSDPS_TIMEOUT_CTRL_OFFSET	0x2EU	/**< Timeout Control */
+#define XSDPS_SW_RST_OFFSET		0x2FU	/**< Software Reset */
+#define XSDPS_NORM_INTR_STS_OFFSET 	0x30U	/**< Normal Interrupt
+							Status Register */
+#define XSDPS_ERR_INTR_STS_OFFSET 	0x32U	/**< Error Interrupt
+							Status Register */
+#define XSDPS_NORM_INTR_STS_EN_OFFSET	0x34U	/**< Normal Interrupt
+						Status Enable Register */
+#define XSDPS_ERR_INTR_STS_EN_OFFSET	0x36U	/**< Error Interrupt
+						Status Enable Register */
+#define XSDPS_NORM_INTR_SIG_EN_OFFSET	0x38U	/**< Normal Interrupt
+						Signal Enable Register */
+#define XSDPS_ERR_INTR_SIG_EN_OFFSET	0x3AU	/**< Error Interrupt
+						Signal Enable Register */
+
+#define XSDPS_AUTO_CMD12_ERR_STS_OFFSET	0x3CU	/**< Auto CMD12 Error Status
+							Register */
+#define XSDPS_HOST_CTRL2_OFFSET		0x3EU	/**< Host Control2 Register */
+#define XSDPS_CAPS_OFFSET 		0x40U	/**< Capabilities Register */
+#define XSDPS_CAPS_EXT_OFFSET 		0x44U	/**< Capabilities Extended */
+#define XSDPS_MAX_CURR_CAPS_OFFSET	0x48U	/**< Maximum Current
+						Capabilities Register */
+#define XSDPS_MAX_CURR_CAPS_EXT_OFFSET	0x4CU	/**< Maximum Current
+						Capabilities Ext Register */
+#define XSDPS_FE_ERR_INT_STS_OFFSET	0x52U	/**< Force Event for
+						Error Interrupt Status */
+#define XSDPS_FE_AUTO_CMD12_EIS_OFFSET	0x50U	/**< Auto CM12 Error Interrupt
+							Status Register */
+#define XSDPS_ADMA_ERR_STS_OFFSET	0x54U	/**< ADMA Error Status
+							Register */
+#define XSDPS_ADMA_SAR_OFFSET		0x58U	/**< ADMA System Address
+							Register */
+#define XSDPS_ADMA_SAR_EXT_OFFSET	0x5CU	/**< ADMA System Address
+							Extended Register */
+#define XSDPS_PRE_VAL_1_OFFSET		0x60U	/**< Preset Value Register */
+#define XSDPS_PRE_VAL_2_OFFSET		0x64U	/**< Preset Value Register */
+#define XSDPS_PRE_VAL_3_OFFSET		0x68U	/**< Preset Value Register */
+#define XSDPS_PRE_VAL_4_OFFSET		0x6CU	/**< Preset Value Register */
+#define XSDPS_BOOT_TOUT_CTRL_OFFSET	0x70U	/**< Boot timeout control
+							register */
+
+#define XSDPS_SHARED_BUS_CTRL_OFFSET	0xE0U	/**< Shared Bus Control
+							Register */
+#define XSDPS_SLOT_INTR_STS_OFFSET	0xFCU	/**< Slot Interrupt Status
+							Register */
+#define XSDPS_HOST_CTRL_VER_OFFSET	0xFEU	/**< Host Controller Version
+							Register */
+
+/* @} */
+
+/** @name Control Register - Host control, Power control,
+ * 			Block Gap control and Wakeup control
+ *
+ * This register contains bits for various configuration options of
+ * the SD host controller. Read/Write apart from the reserved bits.
+ * @{
+ */
+
+#define XSDPS_HC_LED_MASK		0x00000001U /**< LED Control */
+#define XSDPS_HC_WIDTH_MASK		0x00000002U /**< Bus width */
+#define XSDPS_HC_BUS_WIDTH_4		0x00000002U
+#define XSDPS_HC_SPEED_MASK		0x00000004U /**< High Speed */
+#define XSDPS_HC_DMA_MASK		0x00000018U /**< DMA Mode Select */
+#define XSDPS_HC_DMA_SDMA_MASK		0x00000000U /**< SDMA Mode */
+#define XSDPS_HC_DMA_ADMA1_MASK		0x00000008U /**< ADMA1 Mode */
+#define XSDPS_HC_DMA_ADMA2_32_MASK	0x00000010U /**< ADMA2 Mode - 32 bit */
+#define XSDPS_HC_DMA_ADMA2_64_MASK	0x00000018U /**< ADMA2 Mode - 64 bit */
+#define XSDPS_HC_EXT_BUS_WIDTH		0x00000020U /**< Bus width - 8 bit */
+#define XSDPS_HC_CARD_DET_TL_MASK	0x00000040U /**< Card Detect Tst Lvl */
+#define XSDPS_HC_CARD_DET_SD_MASK	0x00000080U /**< Card Detect Sig Det */
+
+#define XSDPS_PC_BUS_PWR_MASK		0x00000001U /**< Bus Power Control */
+#define XSDPS_PC_BUS_VSEL_MASK		0x0000000EU /**< Bus Voltage Select */
+#define XSDPS_PC_BUS_VSEL_3V3_MASK	0x0000000EU /**< Bus Voltage 3.3V */
+#define XSDPS_PC_BUS_VSEL_3V0_MASK	0x0000000CU /**< Bus Voltage 3.0V */
+#define XSDPS_PC_BUS_VSEL_1V8_MASK	0x0000000AU /**< Bus Voltage 1.8V */
+#define XSDPS_PC_EMMC_HW_RST_MASK	0x00000010U /**< HW reset for eMMC */
+
+#define XSDPS_BGC_STP_REQ_MASK		0x00000001U /**< Block Gap Stop Req */
+#define XSDPS_BGC_CNT_REQ_MASK		0x00000002U /**< Block Gap Cont Req */
+#define XSDPS_BGC_RWC_MASK		0x00000004U /**< Block Gap Rd Wait */
+#define XSDPS_BGC_INTR_MASK		0x00000008U /**< Block Gap Intr */
+#define XSDPS_BGC_SPI_MODE_MASK		0x00000010U /**< Block Gap SPI Mode */
+#define XSDPS_BGC_BOOT_EN_MASK		0x00000020U /**< Block Gap Boot Enb */
+#define XSDPS_BGC_ALT_BOOT_EN_MASK	0x00000040U /**< Block Gap Alt BootEn */
+#define XSDPS_BGC_BOOT_ACK_MASK		0x00000080U /**< Block Gap Boot Ack */
+
+#define XSDPS_WC_WUP_ON_INTR_MASK	0x00000001U /**< Wakeup Card Intr */
+#define XSDPS_WC_WUP_ON_INSRT_MASK	0x00000002U /**< Wakeup Card Insert */
+#define XSDPS_WC_WUP_ON_REM_MASK	0x00000004U /**< Wakeup Card Removal */
+
+/* @} */
+
+/** @name Control Register - Clock control, Timeout control & Software reset
+ *
+ * This register contains bits for configuration options of clock, timeout and
+ * software reset.
+ * Read/Write except for Inter_Clock_Stable bit (read only) and reserved bits.
+ * @{
+ */
+
+#define XSDPS_CC_INT_CLK_EN_MASK		0x00000001U
+#define XSDPS_CC_INT_CLK_STABLE_MASK	0x00000002U
+#define XSDPS_CC_SD_CLK_EN_MASK			0x00000004U
+#define XSDPS_CC_SD_CLK_GEN_SEL_MASK		0x00000020U
+#define XSDPS_CC_SDCLK_FREQ_SEL_EXT_MASK	0x000000C0U
+#define XSDPS_CC_SDCLK_FREQ_SEL_MASK		0x0000FF00U
+#define XSDPS_CC_SDCLK_FREQ_D256_MASK		0x00008000U
+#define XSDPS_CC_SDCLK_FREQ_D128_MASK		0x00004000U
+#define XSDPS_CC_SDCLK_FREQ_D64_MASK		0x00002000U
+#define XSDPS_CC_SDCLK_FREQ_D32_MASK		0x00001000U
+#define XSDPS_CC_SDCLK_FREQ_D16_MASK		0x00000800U
+#define XSDPS_CC_SDCLK_FREQ_D8_MASK		0x00000400U
+#define XSDPS_CC_SDCLK_FREQ_D4_MASK		0x00000200U
+#define XSDPS_CC_SDCLK_FREQ_D2_MASK		0x00000100U
+#define XSDPS_CC_SDCLK_FREQ_BASE_MASK	0x00000000U
+#define XSDPS_CC_MAX_DIV_CNT			256U
+#define XSDPS_CC_EXT_MAX_DIV_CNT		2046U
+#define XSDPS_CC_EXT_DIV_SHIFT			6U
+
+#define XSDPS_TC_CNTR_VAL_MASK			0x0000000FU
+
+#define XSDPS_SWRST_ALL_MASK			0x00000001U
+#define XSDPS_SWRST_CMD_LINE_MASK		0x00000002U
+#define XSDPS_SWRST_DAT_LINE_MASK		0x00000004U
+
+#define XSDPS_CC_MAX_NUM_OF_DIV		9U
+#define XSDPS_CC_DIV_SHIFT		8U
+
+/* @} */
+
+/** @name SD Interrupt Registers
+ *
+ * <b> Normal and Error Interrupt Status Register </b>
+ * This register shows the normal and error interrupt status.
+ * Status enable register affects reads of this register.
+ * If Signal enable register is set and the corresponding status bit is set,
+ * interrupt is generated.
+ * Write to clear except
+ * Error_interrupt and Card_Interrupt bits - Read only
+ *
+ * <b> Normal and Error Interrupt Status Enable Register </b>
+ * Setting this register bits enables Interrupt status.
+ * Read/Write except Fixed_to_0 bit (Read only)
+ *
+ * <b> Normal and Error Interrupt Signal Enable Register </b>
+ * This register is used to select which interrupt status is
+ * indicated to the Host System as the interrupt.
+ * Read/Write except Fixed_to_0 bit (Read only)
+ *
+ * All three registers have same bit definitions
+ * @{
+ */
+
+#define XSDPS_INTR_CC_MASK		0x00000001U /**< Command Complete */
+#define XSDPS_INTR_TC_MASK		0x00000002U /**< Transfer Complete */
+#define XSDPS_INTR_BGE_MASK		0x00000004U /**< Block Gap Event */
+#define XSDPS_INTR_DMA_MASK		0x00000008U /**< DMA Interrupt */
+#define XSDPS_INTR_BWR_MASK		0x00000010U /**< Buffer Write Ready */
+#define XSDPS_INTR_BRR_MASK		0x00000020U /**< Buffer Read Ready */
+#define XSDPS_INTR_CARD_INSRT_MASK	0x00000040U /**< Card Insert */
+#define XSDPS_INTR_CARD_REM_MASK	0x00000080U /**< Card Remove */
+#define XSDPS_INTR_CARD_MASK		0x00000100U /**< Card Interrupt */
+#define XSDPS_INTR_INT_A_MASK		0x00000200U /**< INT A Interrupt */
+#define XSDPS_INTR_INT_B_MASK		0x00000400U /**< INT B Interrupt */
+#define XSDPS_INTR_INT_C_MASK		0x00000800U /**< INT C Interrupt */
+#define XSDPS_INTR_RE_TUNING_MASK	0x00001000U /**< Re-Tuning Interrupt */
+#define XSDPS_INTR_BOOT_ACK_RECV_MASK	0x00002000U /**< Boot Ack Recv
+							Interrupt */
+#define XSDPS_INTR_BOOT_TERM_MASK	0x00004000U /**< Boot Terminate
+							Interrupt */
+#define XSDPS_INTR_ERR_MASK		0x00008000U /**< Error Interrupt */
+#define XSDPS_NORM_INTR_ALL_MASK	0x0000FFFFU
+
+#define XSDPS_INTR_ERR_CT_MASK		0x00000001U /**< Command Timeout
+							Error */
+#define XSDPS_INTR_ERR_CCRC_MASK	0x00000002U /**< Command CRC Error */
+#define XSDPS_INTR_ERR_CEB_MASK		0x00000004U /**< Command End Bit
+							Error */
+#define XSDPS_INTR_ERR_CI_MASK		0x00000008U /**< Command Index Error */
+#define XSDPS_INTR_ERR_DT_MASK		0x00000010U /**< Data Timeout Error */
+#define XSDPS_INTR_ERR_DCRC_MASK	0x00000020U /**< Data CRC Error */
+#define XSDPS_INTR_ERR_DEB_MASK		0x00000040U /**< Data End Bit Error */
+#define XSDPS_INTR_ERR_CUR_LMT_MASK	0x00000080U /**< Current Limit Error */
+#define XSDPS_INTR_ERR_AUTO_CMD12_MASK	0x00000100U /**< Auto CMD12 Error */
+#define XSDPS_INTR_ERR_ADMA_MASK	0x00000200U /**< ADMA Error */
+#define XSDPS_INTR_ERR_TR_MASK		0x00001000U /**< Tuning Error */
+#define XSDPS_INTR_VEND_SPF_ERR_MASK	0x0000E000U /**< Vendor Specific
+							Error */
+#define XSDPS_ERROR_INTR_ALL_MASK	0x0000F3FFU /**< Mask for error bits */
+/* @} */
+
+/** @name Block Size and Block Count Register
+ *
+ * This register contains the block count for current transfer,
+ * block size and SDMA buffer size.
+ * Read/Write except for reserved bits.
+ * @{
+ */
+
+#define XSDPS_BLK_SIZE_MASK		0x00000FFFU /**< Transfer Block Size */
+#define XSDPS_SDMA_BUFF_SIZE_MASK	0x00007000U /**< Host SDMA Buffer Size */
+#define XSDPS_BLK_SIZE_1024		0x400U
+#define XSDPS_BLK_SIZE_2048		0x800U
+#define XSDPS_BLK_CNT_MASK		0x0000FFFFU /**< Block Count for
+								Current Transfer */
+
+/* @} */
+
+/** @name Transfer Mode and Command Register
+ *
+ * The Transfer Mode register is used to control the data transfers and
+ * Command register is used for command generation
+ * Read/Write except for reserved bits.
+ * @{
+ */
+
+#define XSDPS_TM_DMA_EN_MASK		0x00000001U /**< DMA Enable */
+#define XSDPS_TM_BLK_CNT_EN_MASK	0x00000002U /**< Block Count Enable */
+#define XSDPS_TM_AUTO_CMD12_EN_MASK	0x00000004U /**< Auto CMD12 Enable */
+#define XSDPS_TM_DAT_DIR_SEL_MASK	0x00000010U /**< Data Transfer
+							Direction Select */
+#define XSDPS_TM_MUL_SIN_BLK_SEL_MASK	0x00000020U /**< Multi/Single
+							Block Select */
+
+#define XSDPS_CMD_RESP_SEL_MASK		0x00000003U /**< Response Type
+							Select */
+#define XSDPS_CMD_RESP_NONE_MASK	0x00000000U /**< No Response */
+#define XSDPS_CMD_RESP_L136_MASK	0x00000001U /**< Response length 138 */
+#define XSDPS_CMD_RESP_L48_MASK		0x00000002U /**< Response length 48 */
+#define XSDPS_CMD_RESP_L48_BSY_CHK_MASK	0x00000003U /**< Response length 48 &
+							check busy after
+							response */
+#define XSDPS_CMD_CRC_CHK_EN_MASK	0x00000008U /**< Command CRC Check
+							Enable */
+#define XSDPS_CMD_INX_CHK_EN_MASK	0x00000010U /**< Command Index Check
+							Enable */
+#define XSDPS_DAT_PRESENT_SEL_MASK	0x00000020U /**< Data Present Select */
+#define XSDPS_CMD_TYPE_MASK		0x000000C0U /**< Command Type */
+#define XSDPS_CMD_TYPE_NORM_MASK	0x00000000U /**< CMD Type - Normal */
+#define XSDPS_CMD_TYPE_SUSPEND_MASK	0x00000040U /**< CMD Type - Suspend */
+#define XSDPS_CMD_TYPE_RESUME_MASK	0x00000080U /**< CMD Type - Resume */
+#define XSDPS_CMD_TYPE_ABORT_MASK	0x000000C0U /**< CMD Type - Abort */
+#define XSDPS_CMD_MASK			0x00003F00U /**< Command Index Mask -
+							Set to CMD0-63,
+							AMCD0-63 */
+
+/* @} */
+
+/** @name Auto CMD Error Status Register
+ *
+ * This register is read only register which contains
+ * information about the error status of Auto CMD 12 and 23.
+ * Read Only
+ * @{
+ */
+#define XSDPS_AUTO_CMD12_NT_EX_MASK	0x0001U /**< Auto CMD12 Not
+							executed */
+#define XSDPS_AUTO_CMD_TOUT_MASK	0x0002U /**< Auto CMD Timeout
+							Error */
+#define XSDPS_AUTO_CMD_CRC_MASK		0x0004U /**< Auto CMD CRC Error */
+#define XSDPS_AUTO_CMD_EB_MASK		0x0008U /**< Auto CMD End Bit
+							Error */
+#define XSDPS_AUTO_CMD_IND_MASK		0x0010U /**< Auto CMD Index Error */
+#define XSDPS_AUTO_CMD_CNI_ERR_MASK	0x0080U /**< Command not issued by
+							Auto CMD12 Error */
+/* @} */
+
+/** @name Host Control2 Register
+ *
+ * This register contains extended configuration bits.
+ * Read Write
+ * @{
+ */
+#define XSDPS_HC2_UHS_MODE_MASK		0x0007U /**< UHS Mode select bits */
+#define XSDPS_HC2_UHS_MODE_SDR12_MASK	0x0000U /**< SDR12 UHS Mode */
+#define XSDPS_HC2_UHS_MODE_SDR25_MASK	0x0001U /**< SDR25 UHS Mode */
+#define XSDPS_HC2_UHS_MODE_SDR50_MASK	0x0002U /**< SDR50 UHS Mode */
+#define XSDPS_HC2_UHS_MODE_SDR104_MASK	0x0003U /**< SDR104 UHS Mode */
+#define XSDPS_HC2_UHS_MODE_DDR50_MASK	0x0004U /**< DDR50 UHS Mode */
+#define XSDPS_HC2_1V8_EN_MASK		0x0008U /**< 1.8V Signal Enable */
+#define XSDPS_HC2_DRV_STR_SEL_MASK	0x0030U /**< Driver Strength
+							Selection */
+#define XSDPS_HC2_DRV_STR_B_MASK	0x0000U /**< Driver Strength B */
+#define XSDPS_HC2_DRV_STR_A_MASK	0x0010U /**< Driver Strength A */
+#define XSDPS_HC2_DRV_STR_C_MASK	0x0020U /**< Driver Strength C */
+#define XSDPS_HC2_DRV_STR_D_MASK	0x0030U /**< Driver Strength D */
+#define XSDPS_HC2_EXEC_TNG_MASK		0x0040U /**< Execute Tuning */
+#define XSDPS_HC2_SAMP_CLK_SEL_MASK	0x0080U /**< Sampling Clock
+							Selection */
+#define XSDPS_HC2_ASYNC_INTR_EN_MASK	0x4000U /**< Asynchronous Interrupt
+							Enable */
+#define XSDPS_HC2_PRE_VAL_EN_MASK	0x8000U /**< Preset Value Enable */
+
+/* @} */
+
+/** @name Capabilities Register
+ *
+ * Capabilities register is a read only register which contains
+ * information about the host controller.
+ * Sufficient if read once after power on.
+ * Read Only
+ * @{
+ */
+#define XSDPS_CAP_TOUT_CLK_FREQ_MASK	0x0000003FU /**< Timeout clock freq
+							select */
+#define XSDPS_CAP_TOUT_CLK_UNIT_MASK	0x00000080U /**< Timeout clock unit -
+							MHz/KHz */
+#define XSDPS_CAP_MAX_BLK_LEN_MASK	0x00030000U /**< Max block length */
+#define XSDPS_CAP_MAX_BLK_LEN_512B_MASK	0x00000000U /**< Max block 512 bytes */
+#define XSDPS_CAP_MAX_BL_LN_1024_MASK	0x00010000U /**< Max block 1024 bytes */
+#define XSDPS_CAP_MAX_BL_LN_2048_MASK	0x00020000U /**< Max block 2048 bytes */
+#define XSDPS_CAP_MAX_BL_LN_4096_MASK	0x00030000U /**< Max block 4096 bytes */
+
+#define XSDPS_CAP_EXT_MEDIA_BUS_MASK	0x00040000U /**< Extended media bus */
+#define XSDPS_CAP_ADMA2_MASK		0x00080000U /**< ADMA2 support */
+#define XSDPS_CAP_HIGH_SPEED_MASK	0x00200000U /**< High speed support */
+#define XSDPS_CAP_SDMA_MASK		0x00400000U /**< SDMA support */
+#define XSDPS_CAP_SUSP_RESUME_MASK	0x00800000U /**< Suspend/Resume
+							support */
+#define XSDPS_CAP_VOLT_3V3_MASK		0x01000000U /**< 3.3V support */
+#define XSDPS_CAP_VOLT_3V0_MASK		0x02000000U /**< 3.0V support */
+#define XSDPS_CAP_VOLT_1V8_MASK		0x04000000U /**< 1.8V support */
+
+#define XSDPS_CAP_SYS_BUS_64_MASK	0x10000000U /**< 64 bit system bus
+							support */
+/* Spec 2.0 */
+#define XSDPS_CAP_INTR_MODE_MASK	0x08000000U /**< Interrupt mode
+							support */
+#define XSDPS_CAP_SPI_MODE_MASK		0x20000000U /**< SPI mode */
+#define XSDPS_CAP_SPI_BLOCK_MODE_MASK	0x40000000U /**< SPI block mode */
+
+
+/* Spec 3.0 */
+#define XSDPS_CAPS_ASYNC_INTR_MASK	0x20000000U /**< Async Interrupt
+							support */
+#define XSDPS_CAPS_SLOT_TYPE_MASK	0xC0000000U /**< Slot Type */
+#define XSDPS_CAPS_REM_CARD			0x00000000U /**< Removable Slot */
+#define XSDPS_CAPS_EMB_SLOT			0x40000000U /**< Embedded Slot */
+#define XSDPS_CAPS_SHR_BUS			0x80000000U /**< Shared Bus Slot */
+
+#define XSDPS_ECAPS_SDR50_MASK		0x00000001U /**< SDR50 Mode support */
+#define XSDPS_ECAPS_SDR104_MASK		0x00000002U /**< SDR104 Mode support */
+#define XSDPS_ECAPS_DDR50_MASK		0x00000004U /**< DDR50 Mode support */
+#define XSDPS_ECAPS_DRV_TYPE_A_MASK	0x00000010U /**< DriverType A support */
+#define XSDPS_ECAPS_DRV_TYPE_C_MASK	0x00000020U /**< DriverType C support */
+#define XSDPS_ECAPS_DRV_TYPE_D_MASK	0x00000040U /**< DriverType D support */
+#define XSDPS_ECAPS_TMR_CNT_MASK	0x00000F00U /**< Timer Count for
+							Re-tuning */
+#define XSDPS_ECAPS_USE_TNG_SDR50_MASK	0x00002000U /**< SDR50 Mode needs
+							tuning */
+#define XSDPS_ECAPS_RE_TNG_MODES_MASK	0x0000C000U /**< Re-tuning modes
+							support */
+#define XSDPS_ECAPS_RE_TNG_MODE1_MASK	0x00000000U /**< Re-tuning mode 1 */
+#define XSDPS_ECAPS_RE_TNG_MODE2_MASK	0x00004000U /**< Re-tuning mode 2 */
+#define XSDPS_ECAPS_RE_TNG_MODE3_MASK	0x00008000U /**< Re-tuning mode 3 */
+#define XSDPS_ECAPS_CLK_MULT_MASK	0x00FF0000U /**< Clock Multiplier value
+							for Programmable clock
+							mode */
+#define XSDPS_ECAPS_SPI_MODE_MASK	0x01000000U /**< SPI mode */
+#define XSDPS_ECAPS_SPI_BLK_MODE_MASK	0x02000000U /**< SPI block mode */
+
+/* @} */
+
+/** @name Present State Register
+ *
+ * Gives the current status of the host controller
+ * Read Only
+ * @{
+ */
+
+#define XSDPS_PSR_INHIBIT_CMD_MASK	0x00000001U /**< Command inhibit - CMD */
+#define XSDPS_PSR_INHIBIT_DAT_MASK	0x00000002U /**< Command Inhibit - DAT */
+#define XSDPS_PSR_DAT_ACTIVE_MASK	0x00000004U /**< DAT line active */
+#define XSDPS_PSR_RE_TUNING_REQ_MASK	0x00000008U /**< Re-tuning request */
+#define XSDPS_PSR_WR_ACTIVE_MASK	0x00000100U /**< Write transfer active */
+#define XSDPS_PSR_RD_ACTIVE_MASK	0x00000200U /**< Read transfer active */
+#define XSDPS_PSR_BUFF_WR_EN_MASK	0x00000400U /**< Buffer write enable */
+#define XSDPS_PSR_BUFF_RD_EN_MASK	0x00000800U /**< Buffer read enable */
+#define XSDPS_PSR_CARD_INSRT_MASK	0x00010000U /**< Card inserted */
+#define XSDPS_PSR_CARD_STABLE_MASK	0x00020000U /**< Card state stable */
+#define XSDPS_PSR_CARD_DPL_MASK		0x00040000U /**< Card detect pin level */
+#define XSDPS_PSR_WPS_PL_MASK		0x00080000U /**< Write protect switch
+								pin level */
+#define XSDPS_PSR_DAT30_SG_LVL_MASK	0x00F00000U /**< Data 3:0 signal lvl */
+#define XSDPS_PSR_CMD_SG_LVL_MASK	0x01000000U /**< Cmd Line signal lvl */
+#define XSDPS_PSR_DAT74_SG_LVL_MASK	0x1E000000U /**< Data 7:4 signal lvl */
+
+/* @} */
+
+/** @name Maximum Current Capabilities Register
+ *
+ * This register is read only register which contains
+ * information about current capabilities at each voltage levels.
+ * Read Only
+ * @{
+ */
+#define XSDPS_MAX_CUR_CAPS_1V8_MASK	0x00000F00U /**< Maximum Current
+							Capability at 1.8V */
+#define XSDPS_MAX_CUR_CAPS_3V0_MASK	0x000000F0U /**< Maximum Current
+							Capability at 3.0V */
+#define XSDPS_MAX_CUR_CAPS_3V3_MASK	0x0000000FU /**< Maximum Current
+							Capability at 3.3V */
+/* @} */
+
+
+/** @name Force Event for Auto CMD Error Status Register
+ *
+ * This register is write only register which contains
+ * control bits to generate events for Auto CMD error status.
+ * Write Only
+ * @{
+ */
+#define XSDPS_FE_AUTO_CMD12_NT_EX_MASK	0x0001U /**< Auto CMD12 Not
+							executed */
+#define XSDPS_FE_AUTO_CMD_TOUT_MASK	0x0002U /**< Auto CMD Timeout
+							Error */
+#define XSDPS_FE_AUTO_CMD_CRC_MASK	0x0004U /**< Auto CMD CRC Error */
+#define XSDPS_FE_AUTO_CMD_EB_MASK	0x0008U /**< Auto CMD End Bit
+							Error */
+#define XSDPS_FE_AUTO_CMD_IND_MASK	0x0010U /**< Auto CMD Index Error */
+#define XSDPS_FE_AUTO_CMD_CNI_ERR_MASK	0x0080U /**< Command not issued by
+							Auto CMD12 Error */
+/* @} */
+
+
+
+/** @name Force Event for Error Interrupt Status Register
+ *
+ * This register is write only register which contains
+ * control bits to generate events of error interrupt status register.
+ * Write Only
+ * @{
+ */
+#define XSDPS_FE_INTR_ERR_CT_MASK	0x0001U /**< Command Timeout
+							Error */
+#define XSDPS_FE_INTR_ERR_CCRC_MASK	0x0002U /**< Command CRC Error */
+#define XSDPS_FE_INTR_ERR_CEB_MASK	0x0004U /**< Command End Bit
+							Error */
+#define XSDPS_FE_INTR_ERR_CI_MASK	0x0008U /**< Command Index Error */
+#define XSDPS_FE_INTR_ERR_DT_MASK	0x0010U /**< Data Timeout Error */
+#define XSDPS_FE_INTR_ERR_DCRC_MASK	0x0020U /**< Data CRC Error */
+#define XSDPS_FE_INTR_ERR_DEB_MASK	0x0040U /**< Data End Bit Error */
+#define XSDPS_FE_INTR_ERR_CUR_LMT_MASK	0x0080U /**< Current Limit Error */
+#define XSDPS_FE_INTR_ERR_AUTO_CMD_MASK	0x0100U /**< Auto CMD Error */
+#define XSDPS_FE_INTR_ERR_ADMA_MASK	0x0200U /**< ADMA Error */
+#define XSDPS_FE_INTR_ERR_TR_MASK	0x1000U /**< Target Response */
+#define XSDPS_FE_INTR_VEND_SPF_ERR_MASK	0xE000U /**< Vendor Specific
+							Error */
+
+/* @} */
+
+/** @name ADMA Error Status Register
+ *
+ * This register is read only register which contains
+ * status information about ADMA errors.
+ * Read Only
+ * @{
+ */
+#define XSDPS_ADMA_ERR_MM_LEN_MASK	0x04U /**< ADMA Length Mismatch
+							Error */
+#define XSDPS_ADMA_ERR_STATE_MASK	0x03U /**< ADMA Error State */
+#define XSDPS_ADMA_ERR_STATE_STOP_MASK	0x00U /**< ADMA Error State
+							STOP */
+#define XSDPS_ADMA_ERR_STATE_FDS_MASK	0x01U /**< ADMA Error State
+							FDS */
+#define XSDPS_ADMA_ERR_STATE_TFR_MASK	0x03U /**< ADMA Error State
+							TFR */
+/* @} */
+
+/** @name Preset Values Register
+ *
+ * This register is read only register which contains
+ * preset values for each of speed modes.
+ * Read Only
+ * @{
+ */
+#define XSDPS_PRE_VAL_SDCLK_FSEL_MASK	0x03FFU /**< SDCLK Frequency
+							Select Value */
+#define XSDPS_PRE_VAL_CLK_GEN_SEL_MASK	0x0400U /**< Clock Generator
+							Mode Select */
+#define XSDPS_PRE_VAL_DRV_STR_SEL_MASK	0xC000U /**< Driver Strength
+							Select Value */
+
+/* @} */
+
+/** @name Slot Interrupt Status Register
+ *
+ * This register is read only register which contains
+ * interrupt slot signal for each slot.
+ * Read Only
+ * @{
+ */
+#define XSDPS_SLOT_INTR_STS_INT_MASK	0x0007U /**< Interrupt Signal
+							mask */
+
+/* @} */
+
+/** @name Host Controller Version Register
+ *
+ * This register is read only register which contains
+ * Host Controller and Vendor Specific version.
+ * Read Only
+ * @{
+ */
+#define XSDPS_HC_VENDOR_VER		0xFF00U /**< Vendor
+							Specification
+							version mask */
+#define XSDPS_HC_SPEC_VER_MASK		0x00FFU /**< Host
+							Specification
+							version mask */
+#define XSDPS_HC_SPEC_V3		0x0002U
+#define XSDPS_HC_SPEC_V2		0x0001U
+#define XSDPS_HC_SPEC_V1		0x0000U
+
+/** @name Block size mask for 512 bytes
+ *
+ * Block size mask for 512 bytes - This is the default block size.
+ * @{
+ */
+
+#define XSDPS_BLK_SIZE_512_MASK	0x200U
+
+/* @} */
+
+/** @name Commands
+ *
+ * Constant definitions for commands and response related to SD
+ * @{
+ */
+
+#define XSDPS_APP_CMD_PREFIX	 0x8000U
+#define CMD0	 0x0000U
+#define CMD1	 0x0100U
+#define CMD2	 0x0200U
+#define CMD3	 0x0300U
+#define CMD4	 0x0400U
+#define CMD5	 0x0500U
+#define CMD6	 0x0600U
+#define ACMD6	(XSDPS_APP_CMD_PREFIX + 0x0600U)
+#define CMD7	 0x0700U
+#define CMD8	 0x0800U
+#define CMD9	 0x0900U
+#define CMD10	 0x0A00U
+#define CMD11	 0x0B00U
+#define CMD12	 0x0C00U
+#define CMD13	 0x0D00U
+#define ACMD13	 (XSDPS_APP_CMD_PREFIX + 0x0D00U)
+#define CMD16	 0x1000U
+#define CMD17	 0x1100U
+#define CMD18	 0x1200U
+#define CMD19	 0x1300U
+#define CMD21	 0x1500U
+#define CMD23	 0x1700U
+#define ACMD23	 (XSDPS_APP_CMD_PREFIX + 0x1700U)
+#define CMD24	 0x1800U
+#define CMD25	 0x1900U
+#define CMD41	 0x2900U
+#define ACMD41	 (XSDPS_APP_CMD_PREFIX + 0x2900U)
+#define ACMD42	 (XSDPS_APP_CMD_PREFIX + 0x2A00U)
+#define ACMD51	 (XSDPS_APP_CMD_PREFIX + 0x3300U)
+#define CMD52	 0x3400U
+#define CMD55	 0x3700U
+#define CMD58	 0x3A00U
+
+#define RESP_NONE	(u32)XSDPS_CMD_RESP_NONE_MASK
+#define RESP_R1		(u32)XSDPS_CMD_RESP_L48_MASK | (u32)XSDPS_CMD_CRC_CHK_EN_MASK | \
+			(u32)XSDPS_CMD_INX_CHK_EN_MASK
+
+#define RESP_R1B	(u32)XSDPS_CMD_RESP_L48_BSY_CHK_MASK | \
+			(u32)XSDPS_CMD_CRC_CHK_EN_MASK | (u32)XSDPS_CMD_INX_CHK_EN_MASK
+
+#define RESP_R2		(u32)XSDPS_CMD_RESP_L136_MASK | (u32)XSDPS_CMD_CRC_CHK_EN_MASK
+#define RESP_R3		(u32)XSDPS_CMD_RESP_L48_MASK
+
+#define RESP_R6		(u32)XSDPS_CMD_RESP_L48_BSY_CHK_MASK | \
+			(u32)XSDPS_CMD_CRC_CHK_EN_MASK | (u32)XSDPS_CMD_INX_CHK_EN_MASK
+
+/* @} */
+
+/* Card Interface Conditions Definitions */
+#define XSDPS_CIC_CHK_PATTERN	0xAAU
+#define XSDPS_CIC_VOLT_MASK	(0xFU<<8)
+#define XSDPS_CIC_VOLT_2V7_3V6	(1U<<8)
+#define XSDPS_CIC_VOLT_LOW	(1U<<9)
+
+/* Operation Conditions Register Definitions */
+#define XSDPS_OCR_PWRUP_STS	(1U<<31)
+#define XSDPS_OCR_CC_STS	(1U<<30)
+#define XSDPS_OCR_S18		(1U<<24)
+#define XSDPS_OCR_3V5_3V6	(1U<<23)
+#define XSDPS_OCR_3V4_3V5	(1U<<22)
+#define XSDPS_OCR_3V3_3V4	(1U<<21)
+#define XSDPS_OCR_3V2_3V3	(1U<<20)
+#define XSDPS_OCR_3V1_3V2	(1U<<19)
+#define XSDPS_OCR_3V0_3V1	(1U<<18)
+#define XSDPS_OCR_2V9_3V0	(1U<<17)
+#define XSDPS_OCR_2V8_2V9	(1U<<16)
+#define XSDPS_OCR_2V7_2V8	(1U<<15)
+#define XSDPS_OCR_1V7_1V95	(1U<<7)
+#define XSDPS_OCR_HIGH_VOL	0x00FF8000U
+#define XSDPS_OCR_LOW_VOL	0x00000080U
+
+/* SD Card Configuration Register Definitions */
+#define XSDPS_SCR_REG_LEN		8U
+#define XSDPS_SCR_STRUCT_MASK		(0xFU<<28)
+#define XSDPS_SCR_SPEC_MASK		(0xFU<<24)
+#define XSDPS_SCR_SPEC_1V0		0U
+#define XSDPS_SCR_SPEC_1V1		(1U<<24)
+#define XSDPS_SCR_SPEC_2V0_3V0		(2U<<24)
+#define XSDPS_SCR_MEM_VAL_AF_ERASE	(1U<<23)
+#define XSDPS_SCR_SEC_SUPP_MASK		(7U<<20)
+#define XSDPS_SCR_SEC_SUPP_NONE		0U
+#define XSDPS_SCR_SEC_SUPP_1V1		(2U<<20)
+#define XSDPS_SCR_SEC_SUPP_2V0		(3U<<20)
+#define XSDPS_SCR_SEC_SUPP_3V0		(4U<<20)
+#define XSDPS_SCR_BUS_WIDTH_MASK	(0xFU<<16)
+#define XSDPS_SCR_BUS_WIDTH_1		(1U<<16)
+#define XSDPS_SCR_BUS_WIDTH_4		(4U<<16)
+#define XSDPS_SCR_SPEC3_MASK		(1U<<12)
+#define XSDPS_SCR_SPEC3_2V0		0U
+#define XSDPS_SCR_SPEC3_3V0		(1U<<12)
+#define XSDPS_SCR_CMD_SUPP_MASK		0x3U
+#define XSDPS_SCR_CMD23_SUPP		(1U<<1)
+#define XSDPS_SCR_CMD20_SUPP		(1U<<0)
+
+/* Card Status Register Definitions */
+#define XSDPS_CD_STS_OUT_OF_RANGE	(1U<<31)
+#define XSDPS_CD_STS_ADDR_ERR		(1U<<30)
+#define XSDPS_CD_STS_BLK_LEN_ERR	(1U<<29)
+#define XSDPS_CD_STS_ER_SEQ_ERR		(1U<<28)
+#define XSDPS_CD_STS_ER_PRM_ERR		(1U<<27)
+#define XSDPS_CD_STS_WP_VIO		(1U<<26)
+#define XSDPS_CD_STS_IS_LOCKED		(1U<<25)
+#define XSDPS_CD_STS_LOCK_UNLOCK_FAIL	(1U<<24)
+#define XSDPS_CD_STS_CMD_CRC_ERR	(1U<<23)
+#define XSDPS_CD_STS_ILGL_CMD		(1U<<22)
+#define XSDPS_CD_STS_CARD_ECC_FAIL	(1U<<21)
+#define XSDPS_CD_STS_CC_ERR		(1U<<20)
+#define XSDPS_CD_STS_ERR		(1U<<19)
+#define XSDPS_CD_STS_CSD_OVRWR		(1U<<16)
+#define XSDPS_CD_STS_WP_ER_SKIP		(1U<<15)
+#define XSDPS_CD_STS_CARD_ECC_DIS	(1U<<14)
+#define XSDPS_CD_STS_ER_RST		(1U<<13)
+#define XSDPS_CD_STS_CUR_STATE		(0xFU<<9)
+#define XSDPS_CD_STS_RDY_FOR_DATA	(1U<<8)
+#define XSDPS_CD_STS_APP_CMD		(1U<<5)
+#define XSDPS_CD_STS_AKE_SEQ_ERR	(1U<<2)
+
+/* Switch Function Definitions CMD6 */
+#define XSDPS_SWITCH_SD_RESP_LEN	64U
+
+#define XSDPS_SWITCH_FUNC_SWITCH	(1U<<31)
+#define XSDPS_SWITCH_FUNC_CHECK		0U
+
+#define XSDPS_MODE_FUNC_GRP1		1U
+#define XSDPS_MODE_FUNC_GRP2		2U
+#define XSDPS_MODE_FUNC_GRP3		3U
+#define XSDPS_MODE_FUNC_GRP4		4U
+#define XSDPS_MODE_FUNC_GRP5		5U
+#define XSDPS_MODE_FUNC_GRP6		6U
+
+#define XSDPS_FUNC_GRP_DEF_VAL		0xFU
+#define XSDPS_FUNC_ALL_GRP_DEF_VAL	0xFFFFFFU
+
+#define XSDPS_ACC_MODE_DEF_SDR12	0U
+#define XSDPS_ACC_MODE_HS_SDR25		1U
+#define XSDPS_ACC_MODE_SDR50		2U
+#define XSDPS_ACC_MODE_SDR104		3U
+#define XSDPS_ACC_MODE_DDR50		4U
+
+#define XSDPS_CMD_SYS_ARG_SHIFT		4U
+#define XSDPS_CMD_SYS_DEF		0U
+#define XSDPS_CMD_SYS_eC		1U
+#define XSDPS_CMD_SYS_OTP		3U
+#define XSDPS_CMD_SYS_ASSD		4U
+#define XSDPS_CMD_SYS_VEND		5U
+
+#define XSDPS_DRV_TYPE_ARG_SHIFT	8U
+#define XSDPS_DRV_TYPE_B		0U
+#define XSDPS_DRV_TYPE_A		1U
+#define XSDPS_DRV_TYPE_C		2U
+#define XSDPS_DRV_TYPE_D		3U
+
+#define XSDPS_CUR_LIM_ARG_SHIFT		12U
+#define XSDPS_CUR_LIM_200		0U
+#define XSDPS_CUR_LIM_400		1U
+#define XSDPS_CUR_LIM_600		2U
+#define XSDPS_CUR_LIM_800		3U
+
+#define CSD_SPEC_VER_MASK		0x3C0000U
+#define READ_BLK_LEN_MASK		0x00000F00U
+#define C_SIZE_MULT_MASK		0x00000380U
+#define C_SIZE_LOWER_MASK		0xFFC00000U
+#define C_SIZE_UPPER_MASK		0x00000003U
+#define CSD_STRUCT_MASK			0x00C00000U
+#define CSD_V2_C_SIZE_MASK		0x3FFFFF00U
+
+/* EXT_CSD field definitions */
+#define XSDPS_EXT_CSD_SIZE		512U
+
+#define EXT_CSD_WR_REL_PARAM_EN		(1U<<2)
+
+#define EXT_CSD_BOOT_WP_B_PWR_WP_DIS    (0x40U)
+#define EXT_CSD_BOOT_WP_B_PERM_WP_DIS   (0x10U)
+#define EXT_CSD_BOOT_WP_B_PERM_WP_EN    (0x04U)
+#define EXT_CSD_BOOT_WP_B_PWR_WP_EN     (0x01U)
+
+#define EXT_CSD_PART_CONFIG_ACC_MASK    (0x7U)
+#define EXT_CSD_PART_CONFIG_ACC_BOOT0   (0x1U)
+#define EXT_CSD_PART_CONFIG_ACC_RPMB    (0x3U)
+#define EXT_CSD_PART_CONFIG_ACC_GP0     (0x4U)
+
+#define EXT_CSD_PART_SUPPORT_PART_EN    (0x1U)
+
+#define EXT_CSD_CMD_SET_NORMAL          (1U<<0)
+#define EXT_CSD_CMD_SET_SECURE          (1U<<1)
+#define EXT_CSD_CMD_SET_CPSECURE        (1U<<2)
+
+#define EXT_CSD_CARD_TYPE_26    	(1U<<0)  /* Card can run at 26MHz */
+#define EXT_CSD_CARD_TYPE_52    	(1U<<1)  /* Card can run at 52MHz */
+#define EXT_CSD_CARD_TYPE_MASK  	0x3FU    /* Mask out reserved bits */
+#define EXT_CSD_CARD_TYPE_DDR_1_8V	(1U<<2)   /* Card can run at 52MHz */
+                                             /* DDR mode @1.8V or 3V I/O */
+#define EXT_CSD_CARD_TYPE_DDR_1_2V	(1U<<3)   /* Card can run at 52MHz */
+                                             /* DDR mode @1.2V I/O */
+#define EXT_CSD_CARD_TYPE_DDR_52	(EXT_CSD_CARD_TYPE_DDR_1_8V  \
+                                        | EXT_CSD_CARD_TYPE_DDR_1_2V)
+#define EXT_CSD_CARD_TYPE_SDR_1_8V      (1U<<4)  /* Card can run at 200MHz */
+#define EXT_CSD_CARD_TYPE_SDR_1_2V      (1U<<5)  /* Card can run at 200MHz */
+                                                /* SDR mode @1.2V I/O */
+#define EXT_CSD_BUS_WIDTH_BYTE			183U
+#define EXT_CSD_BUS_WIDTH_1_BIT			0U	/* Card is in 1 bit mode */
+#define EXT_CSD_BUS_WIDTH_4_BIT			1U	/* Card is in 4 bit mode */
+#define EXT_CSD_BUS_WIDTH_8_BIT			2U	/* Card is in 8 bit mode */
+#define EXT_CSD_BUS_WIDTH_DDR_4_BIT		5U	/* Card is in 4 bit DDR mode */
+#define EXT_CSD_BUS_WIDTH_DDR_8_BIT		6U	/* Card is in 8 bit DDR mode */
+
+#define EXT_CSD_HS_TIMING_BYTE		185U
+#define EXT_CSD_HS_TIMING_DEF		0U
+#define EXT_CSD_HS_TIMING_HIGH		1U	/* Card is in high speed mode */
+#define EXT_CSD_HS_TIMING_HS200		2U	/* Card is in HS200 mode */
+
+#define EXT_CSD_RST_N_FUN_BYTE		162U
+#define EXT_CSD_RST_N_FUN_TEMP_DIS	0U	/* RST_n signal is temporarily disabled */
+#define EXT_CSD_RST_N_FUN_PERM_EN	1U	/* RST_n signal is permanently enabled */
+#define EXT_CSD_RST_N_FUN_PERM_DIS	2U	/* RST_n signal is permanently disabled */
+
+#define XSDPS_EXT_CSD_CMD_SET		0U
+#define XSDPS_EXT_CSD_SET_BITS		1U
+#define XSDPS_EXT_CSD_CLR_BITS		2U
+#define XSDPS_EXT_CSD_WRITE_BYTE	3U
+
+#define XSDPS_MMC_DEF_SPEED_ARG		(((u32)XSDPS_EXT_CSD_WRITE_BYTE << 24) \
+					| ((u32)EXT_CSD_HS_TIMING_BYTE << 16) \
+					| ((u32)EXT_CSD_HS_TIMING_DEF << 8))
+
+#define XSDPS_MMC_HIGH_SPEED_ARG	(((u32)XSDPS_EXT_CSD_WRITE_BYTE << 24) \
+					 | ((u32)EXT_CSD_HS_TIMING_BYTE << 16) \
+					 | ((u32)EXT_CSD_HS_TIMING_HIGH << 8))
+
+#define XSDPS_MMC_HS200_ARG		(((u32)XSDPS_EXT_CSD_WRITE_BYTE << 24) \
+					 | ((u32)EXT_CSD_HS_TIMING_BYTE << 16) \
+					 | ((u32)EXT_CSD_HS_TIMING_HS200 << 8))
+
+#define XSDPS_MMC_1_BIT_BUS_ARG		(((u32)XSDPS_EXT_CSD_WRITE_BYTE << 24) \
+					 | ((u32)EXT_CSD_BUS_WIDTH_BYTE << 16) \
+					 | ((u32)EXT_CSD_BUS_WITH_1_BIT << 8))
+
+#define XSDPS_MMC_4_BIT_BUS_ARG		(((u32)XSDPS_EXT_CSD_WRITE_BYTE << 24) \
+					 | ((u32)EXT_CSD_BUS_WIDTH_BYTE << 16) \
+					 | ((u32)EXT_CSD_BUS_WIDTH_4_BIT << 8))
+
+#define XSDPS_MMC_8_BIT_BUS_ARG		(((u32)XSDPS_EXT_CSD_WRITE_BYTE << 24) \
+					 | ((u32)EXT_CSD_BUS_WIDTH_BYTE << 16) \
+					 | ((u32)EXT_CSD_BUS_WIDTH_8_BIT << 8))
+
+#define XSDPS_MMC_DDR_4_BIT_BUS_ARG		(((u32)XSDPS_EXT_CSD_WRITE_BYTE << 24) \
+					 | ((u32)EXT_CSD_BUS_WIDTH_BYTE << 16) \
+					 | ((u32)EXT_CSD_BUS_WIDTH_DDR_4_BIT << 8))
+
+#define XSDPS_MMC_DDR_8_BIT_BUS_ARG		(((u32)XSDPS_EXT_CSD_WRITE_BYTE << 24) \
+					 | ((u32)EXT_CSD_BUS_WIDTH_BYTE << 16) \
+					 | ((u32)EXT_CSD_BUS_WIDTH_DDR_8_BIT << 8))
+
+#define XSDPS_MMC_RST_FUN_EN_ARG		(((u32)XSDPS_EXT_CSD_WRITE_BYTE << 24) \
+					 | ((u32)EXT_CSD_RST_N_FUN_BYTE << 16) \
+					 | ((u32)EXT_CSD_RST_N_FUN_PERM_EN << 8))
+
+#define XSDPS_MMC_DELAY_FOR_SWITCH	1000U
+
+/* @} */
+
+/* @400KHz, in usec */
+#define XSDPS_74CLK_DELAY	2960U
+#define XSDPS_100CLK_DELAY	4000U
+#define XSDPS_INIT_DELAY	10000U
+
+#define XSDPS_DEF_VOLT_LVL	XSDPS_PC_BUS_VSEL_3V0_MASK
+#define XSDPS_CARD_DEF_ADDR	0x1234U
+
+#define XSDPS_CARD_SD		1U
+#define XSDPS_CARD_MMC		2U
+#define XSDPS_CARD_SDIO		3U
+#define XSDPS_CARD_SDCOMBO	4U
+#define XSDPS_CHIP_EMMC		5U
+
+
+/** @name ADMA2 Descriptor related definitions
+ *
+ * ADMA2 Descriptor related definitions
+ * @{
+ */
+
+#define XSDPS_DESC_MAX_LENGTH 65536U
+
+#define XSDPS_DESC_VALID     	(0x1U << 0)
+#define XSDPS_DESC_END       	(0x1U << 1)
+#define XSDPS_DESC_INT       	(0x1U << 2)
+#define XSDPS_DESC_TRAN  	(0x2U << 4)
+
+/* @} */
+
+/* For changing clock frequencies */
+#define XSDPS_CLK_400_KHZ		400000U		/**< 400 KHZ */
+#define XSDPS_CLK_50_MHZ		50000000U	/**< 50 MHZ */
+#define XSDPS_CLK_52_MHZ		52000000U	/**< 52 MHZ */
+#define XSDPS_SD_VER_1_0		0x1U		/**< SD ver 1 */
+#define XSDPS_SD_VER_2_0		0x2U		/**< SD ver 2 */
+#define XSDPS_SCR_BLKCNT	1U
+#define XSDPS_SCR_BLKSIZE	8U
+#define XSDPS_1_BIT_WIDTH	0x1U
+#define XSDPS_4_BIT_WIDTH	0x2U
+#define XSDPS_8_BIT_WIDTH	0x3U
+#define XSDPS_UHS_SPEED_MODE_SDR12	0x0U
+#define XSDPS_UHS_SPEED_MODE_SDR25	0x1U
+#define XSDPS_UHS_SPEED_MODE_SDR50	0x2U
+#define XSDPS_UHS_SPEED_MODE_SDR104	0x3U
+#define XSDPS_UHS_SPEED_MODE_DDR50	0x4U
+#define XSDPS_HIGH_SPEED_MODE		0x5U
+#define XSDPS_DEFAULT_SPEED_MODE	0x6U
+#define XSDPS_HS200_MODE			0x7U
+#define XSDPS_DDR52_MODE			0x4U
+#define XSDPS_SWITCH_CMD_BLKCNT		1U
+#define XSDPS_SWITCH_CMD_BLKSIZE	64U
+#define XSDPS_SWITCH_CMD_HS_GET		0x00FFFFF0U
+#define XSDPS_SWITCH_CMD_HS_SET		0x80FFFFF1U
+#define XSDPS_SWITCH_CMD_SDR12_SET		0x80FFFFF0U
+#define XSDPS_SWITCH_CMD_SDR25_SET		0x80FFFFF1U
+#define XSDPS_SWITCH_CMD_SDR50_SET		0x80FFFFF2U
+#define XSDPS_SWITCH_CMD_SDR104_SET		0x80FFFFF3U
+#define XSDPS_SWITCH_CMD_DDR50_SET		0x80FFFFF4U
+#define XSDPS_EXT_CSD_CMD_BLKCNT	1U
+#define XSDPS_EXT_CSD_CMD_BLKSIZE	512U
+#define XSDPS_TUNING_CMD_BLKCNT		1U
+#define XSDPS_TUNING_CMD_BLKSIZE	64U
+
+#define XSDPS_HIGH_SPEED_MAX_CLK	50000000U
+#define XSDPS_UHS_SDR104_MAX_CLK	208000000U
+#define XSDPS_UHS_SDR50_MAX_CLK		100000000U
+#define XSDPS_UHS_DDR50_MAX_CLK		50000000U
+#define XSDPS_UHS_SDR25_MAX_CLK		50000000U
+#define XSDPS_UHS_SDR12_MAX_CLK		25000000U
+
+#define SD_DRIVER_TYPE_B	0x01U
+#define SD_DRIVER_TYPE_A	0x02U
+#define SD_DRIVER_TYPE_C	0x04U
+#define SD_DRIVER_TYPE_D	0x08U
+#define SD_SET_CURRENT_LIMIT_200	0U
+#define SD_SET_CURRENT_LIMIT_400	1U
+#define SD_SET_CURRENT_LIMIT_600	2U
+#define SD_SET_CURRENT_LIMIT_800	3U
+
+#define SD_MAX_CURRENT_200	(1U << SD_SET_CURRENT_LIMIT_200)
+#define SD_MAX_CURRENT_400	(1U << SD_SET_CURRENT_LIMIT_400)
+#define SD_MAX_CURRENT_600	(1U << SD_SET_CURRENT_LIMIT_600)
+#define SD_MAX_CURRENT_800	(1U << SD_SET_CURRENT_LIMIT_800)
+
+#define XSDPS_SD_SDR12_MAX_CLK	25000000U
+#define XSDPS_SD_SDR25_MAX_CLK	50000000U
+#define XSDPS_SD_SDR50_MAX_CLK	100000000U
+#define XSDPS_SD_DDR50_MAX_CLK	50000000U
+#define XSDPS_SD_SDR104_MAX_CLK	208000000U
+/*
+ * XSDPS_SD_INPUT_MAX_CLK is set to 175000000 in order to keep it smaller
+ * than the clock value coming from the core. This value is kept to safely
+ * switch to SDR104 mode if the SD card supports it.
+ */
+#define XSDPS_SD_INPUT_MAX_CLK	175000000U
+
+#define XSDPS_MMC_HS200_MAX_CLK	200000000U
+#define XSDPS_MMC_HSD_MAX_CLK	52000000U
+#define XSDPS_MMC_DDR_MAX_CLK	52000000U
+
+#define XSDPS_CARD_STATE_IDLE		0U
+#define XSDPS_CARD_STATE_RDY		1U
+#define XSDPS_CARD_STATE_IDEN		2U
+#define XSDPS_CARD_STATE_STBY		3U
+#define XSDPS_CARD_STATE_TRAN		4U
+#define XSDPS_CARD_STATE_DATA		5U
+#define XSDPS_CARD_STATE_RCV		6U
+#define XSDPS_CARD_STATE_PROG		7U
+#define XSDPS_CARD_STATE_DIS		8U
+#define XSDPS_CARD_STATE_BTST		9U
+#define XSDPS_CARD_STATE_SLP		10U
+
+#define XSDPS_SLOT_REM			0U
+#define XSDPS_SLOT_EMB			1U
+
+#define XSDPS_WIDTH_8		8U
+#define XSDPS_WIDTH_4		4U
+
+
+#if defined (ARMR5) || defined (__aarch64__) || defined (ARMA53_32) || defined (__MICROBLAZE__)
+#ifdef versal
+#define SD_ITAPDLY_SEL_MASK			0x000000FFU
+#define SD_OTAPDLY_SEL_MASK			0x0000003FU
+#define SD_ITAPDLY					0x0000F0F8U
+#define SD_OTAPDLY					0x0000F0FCU
+#define SD_ITAPCHGWIN				0x00000200U
+#define SD_ITAPDLYENA				0x00000100U
+#define SD_OTAPDLYENA				0x00000040U
+#define SD_OTAPDLYSEL_HS200_B0		0x00000002U
+#define SD_OTAPDLYSEL_HS200_B2		0x00000002U
+#define SD_ITAPDLYSEL_SD50			0x0000000EU
+#define SD_OTAPDLYSEL_SD50			0x00000003U
+#define SD_ITAPDLYSEL_SD_DDR50		0x00000036U
+#define SD_ITAPDLYSEL_EMMC_DDR50	0x0000001EU
+#define SD_OTAPDLYSEL_SD_DDR50		0x00000003U
+#define SD_OTAPDLYSEL_EMMC_DDR50	0x00000005U
+#define SD_ITAPDLYSEL_HSD			0x0000002CU
+#define SD_OTAPDLYSEL_SD_HSD		0x00000004U
+#define SD_OTAPDLYSEL_EMMC_HSD		0x00000005U
+#else
+#define SD0_ITAPDLY_SEL_MASK		0x000000FFU
+#define SD0_OTAPDLY_SEL_MASK		0x0000003FU
+#define SD1_ITAPDLY_SEL_MASK		0x00FF0000U
+#define SD1_OTAPDLY_SEL_MASK		0x003F0000U
+#define SD_DLL_CTRL 				0x00000358U
+#define SD_ITAPDLY					0x00000314U
+#define SD_OTAPDLY					0x00000318U
+#define SD0_DLL_RST					0x00000004U
+#define SD1_DLL_RST					0x00040000U
+#define SD0_ITAPCHGWIN				0x00000200U
+#define SD0_ITAPDLYENA				0x00000100U
+#define SD0_OTAPDLYENA				0x00000040U
+#define SD1_ITAPCHGWIN				0x02000000U
+#define SD1_ITAPDLYENA				0x01000000U
+#define SD1_OTAPDLYENA				0x00400000U
+#define SD_OTAPDLYSEL_HS200_B0		0x00000003U
+#define SD_OTAPDLYSEL_HS200_B2		0x00000002U
+#define SD_ITAPDLYSEL_SD50			0x00000014U
+#define SD_OTAPDLYSEL_SD50			0x00000003U
+#define SD_ITAPDLYSEL_SD_DDR50		0x0000003DU
+#define SD_ITAPDLYSEL_EMMC_DDR50	0x00000012U
+#define SD_OTAPDLYSEL_SD_DDR50		0x00000004U
+#define SD_OTAPDLYSEL_EMMC_DDR50	0x00000006U
+#define SD_ITAPDLYSEL_HSD			0x00000015U
+#define SD_OTAPDLYSEL_SD_HSD		0x00000005U
+#define SD_OTAPDLYSEL_EMMC_HSD		0x00000006U
+#endif
+
+#endif
+
+#ifdef __MICROBLAZE__
+#define XPS_SYS_CTRL_BASEADDR	0xFF180000U
+#endif
+
+/**************************** Type Definitions *******************************/
+
+/***************** Macros (Inline Functions) Definitions *********************/
+#define XSdPs_In64 Xil_In64
+#define XSdPs_Out64 Xil_Out64
+
+#define XSdPs_In32 Xil_In32
+#define XSdPs_Out32 Xil_Out32
+
+#define XSdPs_In16 Xil_In16
+#define XSdPs_Out16 Xil_Out16
+
+#define XSdPs_In8 Xil_In8
+#define XSdPs_Out8 Xil_Out8
+
+/****************************************************************************/
+/**
+* Read a register.
+*
+* @param	InstancePtr is the pointer to the sdps instance.
+* @param	RegOffset contains the offset from the 1st register of the
+*		device to the target register.
+*
+* @return	The value read from the register.
+*
+* @note		C-Style signature:
+*		u32 XSdPs_ReadReg(XSdPs *InstancePtr. s32 RegOffset)
+*
+******************************************************************************/
+#define XSdPs_ReadReg64(InstancePtr, RegOffset) \
+	XSdPs_In64((InstancePtr->Config.BaseAddress) + RegOffset)
+
+/***************************************************************************/
+/**
+* Write to a register.
+*
+* @param	InstancePtr is the pointer to the sdps instance.
+* @param	RegOffset contains the offset from the 1st register of the
+*		device to target register.
+* @param	RegisterValue is the value to be written to the register.
+*
+* @return	None.
+*
+* @note		C-Style signature:
+*		void XSdPs_WriteReg(XSdPs *InstancePtr, s32 RegOffset,
+*		u64 RegisterValue)
+*
+******************************************************************************/
+#define XSdPs_WriteReg64(InstancePtr, RegOffset, RegisterValue) \
+	XSdPs_Out64((InstancePtr->Config.BaseAddress) + (RegOffset), \
+		(RegisterValue))
+
+/****************************************************************************/
+/**
+* Read a register.
+*
+* @param	BaseAddress contains the base address of the device.
+* @param	RegOffset contains the offset from the 1st register of the
+*		device to the target register.
+*
+* @return	The value read from the register.
+*
+* @note		C-Style signature:
+*		u32 XSdPs_ReadReg(u32 BaseAddress. int RegOffset)
+*
+******************************************************************************/
+#define XSdPs_ReadReg(BaseAddress, RegOffset) \
+	XSdPs_In32((BaseAddress) + (RegOffset))
+
+/***************************************************************************/
+/**
+* Write to a register.
+*
+* @param	BaseAddress contains the base address of the device.
+* @param	RegOffset contains the offset from the 1st register of the
+*		device to target register.
+* @param	RegisterValue is the value to be written to the register.
+*
+* @return	None.
+*
+* @note		C-Style signature:
+*		void XSdPs_WriteReg(u32 BaseAddress, int RegOffset,
+*		u32 RegisterValue)
+*
+******************************************************************************/
+#define XSdPs_WriteReg(BaseAddress, RegOffset, RegisterValue) \
+	XSdPs_Out32((BaseAddress) + (RegOffset), (RegisterValue))
+
+/****************************************************************************/
+/**
+* Read a register.
+*
+* @param	BaseAddress contains the base address of the device.
+* @param	RegOffset contains the offset from the 1st register of the
+*		device to the target register.
+*
+* @return	The value read from the register.
+*
+* @note		C-Style signature:
+*		u16 XSdPs_ReadReg(u32 BaseAddress. int RegOffset)
+*
+******************************************************************************/
+#define INLINE __inline
+static INLINE u16 XSdPs_ReadReg16(u32 BaseAddress, u8 RegOffset)
+{
+#if defined (__MICROBLAZE__)
+	u32 Reg;
+	BaseAddress += RegOffset & 0xFC;
+	Reg = XSdPs_In32(BaseAddress);
+	Reg >>= ((RegOffset & 0x3)*8);
+	return (u16)Reg;
+#else
+	return XSdPs_In16((BaseAddress) + (RegOffset));
+#endif
+}
+
+/***************************************************************************/
+/**
+* Write to a register.
+*
+* @param	BaseAddress contains the base address of the device.
+* @param	RegOffset contains the offset from the 1st register of the
+*		device to target register.
+* @param	RegisterValue is the value to be written to the register.
+*
+* @return	None.
+*
+* @note		C-Style signature:
+*		void XSdPs_WriteReg(u32 BaseAddress, int RegOffset,
+*		u16 RegisterValue)
+*
+******************************************************************************/
+
+static INLINE void XSdPs_WriteReg16(u32 BaseAddress, u8 RegOffset, u16 RegisterValue)
+{
+#if defined (__MICROBLAZE__)
+	u32 Reg;
+	BaseAddress += RegOffset & 0xFC;
+	Reg = XSdPs_In32(BaseAddress);
+	Reg &= ~(0xFFFF<<((RegOffset & 0x3)*8));
+	Reg |= RegisterValue <<((RegOffset & 0x3)*8);
+	XSdPs_Out32(BaseAddress, Reg);
+#else
+	XSdPs_Out16((BaseAddress) + (RegOffset), (RegisterValue));
+#endif
+}
+
+/****************************************************************************/
+/**
+* Read a register.
+*
+* @param	BaseAddress contains the base address of the device.
+* @param	RegOffset contains the offset from the 1st register of the
+*		device to the target register.
+*
+* @return	The value read from the register.
+*
+* @note		C-Style signature:
+*		u8 XSdPs_ReadReg(u32 BaseAddress. int RegOffset)
+*
+******************************************************************************/
+static INLINE u8 XSdPs_ReadReg8(u32 BaseAddress, u8 RegOffset)
+{
+#if defined (__MICROBLAZE__)
+	u32 Reg;
+	BaseAddress += RegOffset & 0xFC;
+	Reg = XSdPs_In32(BaseAddress);
+	Reg >>= ((RegOffset & 0x3)*8);
+	return (u8)Reg;
+#else
+	return XSdPs_In8((BaseAddress) + (RegOffset));
+#endif
+}
+/***************************************************************************/
+/**
+* Write to a register.
+*
+* @param	BaseAddress contains the base address of the device.
+* @param	RegOffset contains the offset from the 1st register of the
+*		device to target register.
+* @param	RegisterValue is the value to be written to the register.
+*
+* @return	None.
+*
+* @note		C-Style signature:
+*		void XSdPs_WriteReg(u32 BaseAddress, int RegOffset,
+*		u8 RegisterValue)
+*
+******************************************************************************/
+static INLINE void XSdPs_WriteReg8(u32 BaseAddress, u8 RegOffset, u8 RegisterValue)
+{
+#if defined (__MICROBLAZE__)
+	u32 Reg;
+	BaseAddress += RegOffset & 0xFC;
+	Reg = XSdPs_In32(BaseAddress);
+	Reg &= ~(0xFF<<((RegOffset & 0x3)*8));
+	Reg |= RegisterValue <<((RegOffset & 0x3)*8);
+	XSdPs_Out32(BaseAddress, Reg);
+#else
+	XSdPs_Out8((BaseAddress) + (RegOffset), (RegisterValue));
+#endif
+}
+/***************************************************************************/
+/**
+* Macro to get present status register
+*
+* @param	BaseAddress contains the base address of the device.
+*
+* @return	None.
+*
+* @note		C-Style signature:
+*		void XSdPs_WriteReg(u32 BaseAddress, int RegOffset,
+*		u8 RegisterValue)
+*
+******************************************************************************/
+#define XSdPs_GetPresentStatusReg(BaseAddress) \
+		XSdPs_In32((BaseAddress) + (XSDPS_PRES_STATE_OFFSET))
+
+/************************** Function Prototypes ******************************/
+
+/************************** Variable Definitions *****************************/
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SD_HW_H_ */
+/** @} */

--- a/portable/Zynq.2019.3/xsdps_info.c
+++ b/portable/Zynq.2019.3/xsdps_info.c
@@ -1,0 +1,300 @@
+/******************************************************************************
+ *
+ * mmc_decode_cid() and sd_decode_csd()
+ *
+ * analyse the meta data of an SD-card to read its capacity and some other properties.
+ *
+ * CID and CSD Analysis borrowed from the Linux kernel.
+ *
+ ******************************************************************************/
+
+#include "xsdps.h"
+
+#include "xparameters.h"
+#include "xil_cache.h"
+
+#include "ff_headers.h"
+
+#include "xsdps_info.h"
+
+struct mmc_cid myCID;
+struct mmc_csd myCSD;
+
+u32 UNSTUFF_BITS( u32 *ulResponse, int iFirst, int iSize )
+{
+const u32 ulMask = ( iSize < 32 ? ( 1 << iSize ) : 0 ) - 1;
+const int iOffset = 3 - ( iFirst / 32);
+const int iShiftCount = iFirst & 31;
+u32 ulResult;
+
+	ulResult = ulResponse[ iOffset ] >> iShiftCount;
+	if( iSize + iShiftCount > 32 )
+	{
+		ulResult |= ulResponse[ iOffset - 1 ] << ( ( 32 - iShiftCount ) % 32 );
+	}
+	return ulResult & ulMask;						\
+}
+
+int mmc_decode_cid( const struct mmc_csd *pxCSD, struct mmc_cid *pxCID, u32 *ulResponse )
+{
+int iResult = 0;
+
+	/*
+	 * The selection of the format here is based upon published
+	 * specs from sandisk and from what people have reported.
+	 */
+
+	switch( pxCSD->mmca_vsn )
+	{
+	case 0: /* MMC v1.0 - v1.2 */
+	case 1: /* MMC v1.4 */
+		pxCID->manfid         = UNSTUFF_BITS( ulResponse, 104, 24 );
+		pxCID->prod_name[ 0 ] = UNSTUFF_BITS( ulResponse, 96, 8 );
+		pxCID->prod_name[ 1 ] = UNSTUFF_BITS( ulResponse, 88, 8 );
+		pxCID->prod_name[ 2 ] = UNSTUFF_BITS( ulResponse, 80, 8 );
+		pxCID->prod_name[ 3 ] = UNSTUFF_BITS( ulResponse, 72, 8 );
+		pxCID->prod_name[ 4 ] = UNSTUFF_BITS( ulResponse, 64, 8 );
+		pxCID->prod_name[ 5 ] = UNSTUFF_BITS( ulResponse, 56, 8 );
+		pxCID->prod_name[ 6 ] = UNSTUFF_BITS( ulResponse, 48, 8 );
+		pxCID->hwrev          = UNSTUFF_BITS( ulResponse, 44, 4 );
+		pxCID->fwrev          = UNSTUFF_BITS( ulResponse, 40, 4 );
+		pxCID->serial         = UNSTUFF_BITS( ulResponse, 16, 24 );
+		pxCID->month          = UNSTUFF_BITS( ulResponse, 12, 4 );
+		pxCID->year           = UNSTUFF_BITS( ulResponse, 8, 4 ) + 1997;
+		break;
+
+	case 2: /* MMC v2.0 - v2.2 */
+	case 3: /* MMC v3.1 - v3.3 */
+	case 4: /* MMC v4 */
+		pxCID->manfid         = UNSTUFF_BITS( ulResponse, 120, 8 );
+		pxCID->oemid          = UNSTUFF_BITS( ulResponse, 104, 16 );
+		pxCID->prod_name[ 0 ] = UNSTUFF_BITS( ulResponse, 96, 8 );
+		pxCID->prod_name[ 1 ] = UNSTUFF_BITS( ulResponse, 88, 8 );
+		pxCID->prod_name[ 2 ] = UNSTUFF_BITS( ulResponse, 80, 8 );
+		pxCID->prod_name[ 3 ] = UNSTUFF_BITS( ulResponse, 72, 8 );
+		pxCID->prod_name[ 4 ] = UNSTUFF_BITS( ulResponse, 64, 8 );
+		pxCID->prod_name[ 5 ] = UNSTUFF_BITS( ulResponse, 56, 8 );
+		pxCID->serial         = UNSTUFF_BITS( ulResponse, 16, 32 );
+		pxCID->month          = UNSTUFF_BITS( ulResponse, 12, 4 );
+		pxCID->year           = UNSTUFF_BITS( ulResponse, 8, 4 ) + 1997;
+		break;
+
+	default:
+		FF_PRINTF ("mmc_decode_cid: card has unknown MMCA version %d\n",
+			pxCSD->mmca_vsn);
+		iResult = -1;
+		break;
+	}
+	if( iResult >= 0 )
+	{
+		FF_PRINTF ("CID: Manfid %lu (%-8.8s) serial %lu oem %u mon/year %u/%u rev %u fw %u\n",
+			pxCID->manfid,
+			pxCID->prod_name,
+			pxCID->serial,
+			pxCID->oemid,
+			pxCID->month,
+			pxCID->year,
+			pxCID->hwrev,
+			pxCID->fwrev);
+	}
+
+	return iResult;
+}
+
+static const unsigned int tran_exp[] =
+{
+	10000,		100000,		1000000,	10000000,
+	0,		0,		0,		0
+};
+
+static const unsigned char tran_mant[] =
+{
+	0,	10,	12,	13,	15,	20,	25,	30,
+	35,	40,	45,	50,	55,	60,	70,	80,
+};
+
+static const unsigned int tacc_exp[] =
+{
+	1,	10,	100,	1000,	10000,	100000,	1000000, 10000000,
+};
+
+static const unsigned int tacc_mant[] =
+{
+	0,	10,	12,	13,	15,	20,	25,	30,
+	35,	40,	45,	50,	55,	60,	70,	80,
+};
+
+char mmc_is_block_addressed;
+
+/* Given a 128-bit response, decode to our card CSD structure. */
+
+static __inline unsigned tobe32( unsigned value )
+{
+	return
+		( value >> 24 ) |
+		( ( value >>  8 ) & 0x0000ff00 ) |
+		( ( value <<  8 ) & 0x00ff0000 ) |
+		( value << 24 );
+	
+}
+
+int sd_decode_csd( struct mmc_csd *pxCSD, u32 *ulResponse )
+{
+unsigned int e, m, csd_struct;
+int iResult = 0;
+
+	csd_struct = UNSTUFF_BITS( ulResponse, 126, 2 );
+
+	pxCSD->mmca_vsn = UNSTUFF_BITS( ulResponse, 122, 4 );
+
+	FF_PRINTF("CSD data: %08x %08x %08x %08x mmca_vsn = %u\n",
+		( unsigned )ulResponse[0],
+		( unsigned )ulResponse[1],
+		( unsigned )ulResponse[2],
+		( unsigned )ulResponse[3],
+		pxCSD->mmca_vsn);
+//	pxCSD->mmca_vsn = 2;
+
+	// CSD data: 005e0032 5f5a83cb 2db7ffbf 9680000f
+	// sd_decode_csd: capacity 1989120 (byte addressed)
+	switch (csd_struct) {
+	case 0:
+		m = UNSTUFF_BITS( ulResponse, 115, 4 );
+		e = UNSTUFF_BITS( ulResponse, 112, 3 );
+		pxCSD->tacc_ns = ( tacc_exp[ e ] * tacc_mant[ m ] + 9 ) / 10;
+		pxCSD->tacc_clks = UNSTUFF_BITS( ulResponse, 104, 8 ) * 100;
+
+		m = UNSTUFF_BITS( ulResponse, 99, 4 );
+		e = UNSTUFF_BITS( ulResponse, 96, 3 );
+		pxCSD->max_dtr = tran_exp[ e ] * tran_mant[ m ];
+		pxCSD->cmdclass = UNSTUFF_BITS( ulResponse, 84, 12 );
+
+		e = UNSTUFF_BITS( ulResponse, 47, 3 );
+		m = UNSTUFF_BITS( ulResponse, 62, 12 );
+		pxCSD->capacity = ( 1 + m ) << ( e + 2 );
+		/*
+		 * The CSD capacity field is in units of read_blkbits.
+		 * set_capacity takes units of 512 bytes.
+		 */
+
+		pxCSD->read_blkbits = UNSTUFF_BITS( ulResponse, 80, 4 );
+		pxCSD->read_partial = UNSTUFF_BITS( ulResponse, 79, 1 );
+		pxCSD->write_misalign = UNSTUFF_BITS( ulResponse, 78, 1 );
+		pxCSD->read_misalign = UNSTUFF_BITS( ulResponse, 77, 1 );
+		pxCSD->r2w_factor = UNSTUFF_BITS( ulResponse, 26, 3 );
+		pxCSD->write_blkbits = UNSTUFF_BITS( ulResponse, 22, 4 );
+		pxCSD->write_partial = UNSTUFF_BITS( ulResponse, 21, 1 );
+
+		pxCSD->capacity <<= ( pxCSD->read_blkbits - 9 );
+		FF_PRINTF ("Capacity: (%u + 1) << (%u + 2) = %u Rd/Wr bits %u/%u\n",
+			m, e,
+			( unsigned )pxCSD->capacity,
+			( unsigned )pxCSD->read_blkbits,
+			( unsigned )pxCSD->write_blkbits);
+
+		if( UNSTUFF_BITS( ulResponse, 46, 1 ) )
+		{
+			pxCSD->erase_size = 1;
+		}
+		else if( pxCSD->write_blkbits >= 9 )
+		{
+			pxCSD->erase_size = UNSTUFF_BITS( ulResponse, 39, 7 ) + 1;
+			pxCSD->erase_size <<= pxCSD->write_blkbits - 9;
+		}
+		else
+		{
+			pxCSD->erase_size = 0; // Card is not eraseble
+		}
+		break;
+
+	case 1:
+		/*
+		 * This is a block-addressed SDHC card. Most
+		 * interesting fields are unused and have fixed
+		 * values. To avoid getting tripped by buggy cards,
+		 * we assume those fixed values ourselves.
+		 */
+		mmc_is_block_addressed = 1;
+
+		pxCSD->tacc_ns = 0; /* Unused */
+		pxCSD->tacc_clks = 0; /* Unused */
+
+		m = UNSTUFF_BITS( ulResponse, 99, 4 );
+		e = UNSTUFF_BITS( ulResponse, 96, 3 );
+		// max_dtr gives 25,000,000
+		pxCSD->max_dtr = tran_exp[ e ] * tran_mant[ m ];
+		// cmdClass gives: 10110110101 (0x5B5)
+		pxCSD->cmdclass = UNSTUFF_BITS( ulResponse, 84, 12 );
+
+		m = UNSTUFF_BITS( ulResponse, 48, 22 );
+		pxCSD->capacity = ( 1 + m ) << 10;
+
+		FF_PRINTF( "capacity: (1 + %u) << 10  DTR %u Mhz\n", m, pxCSD->max_dtr / 1000000);
+
+		pxCSD->read_blkbits = 9;
+		pxCSD->read_partial = 0;
+		pxCSD->write_misalign = 0;
+		pxCSD->read_misalign = 0;
+		pxCSD->r2w_factor = 4; /* Unused */
+		pxCSD->write_blkbits = 9;
+		pxCSD->write_partial = 0;
+		pxCSD->erase_size = 1;
+		break;
+	default:
+		FF_PRINTF ("sd_decode_csd: unrecognised CSD structure version %d\n", csd_struct);
+		iResult = -1;
+		break;
+	}
+	if( iResult >= 0 )
+	{
+	unsigned int sz;
+
+		FF_PRINTF ("sd_decode_csd: capacity %lu (%s addressed)\n",
+			pxCSD->capacity, mmc_is_block_addressed ? "block" : "byte");
+
+		sz = (pxCSD->capacity << (pxCSD->read_blkbits - 9)) >> 11;
+		if (sz < 128)
+		{
+			pxCSD->pref_erase = 512 * 1024 / 512;
+		}
+		else if (sz < 512)
+		{
+			pxCSD->pref_erase = 1024 * 1024 / 512;
+		}
+		else if (sz < 1024)
+		{
+			pxCSD->pref_erase = 2 * 1024 * 1024 / 512;
+		}
+		else
+		{
+			pxCSD->pref_erase = 4 * 1024 * 1024 / 512;
+		}
+
+		if (pxCSD->pref_erase < pxCSD->erase_size)
+		{
+			pxCSD->pref_erase = pxCSD->erase_size;
+		}
+		else
+		{
+			sz = ( pxCSD->pref_erase % pxCSD->erase_size );
+			if( sz != 0 )
+			{
+				pxCSD->pref_erase += ( pxCSD->erase_size - sz );
+			}
+		}
+
+		// compute last block addr
+
+		pxCSD->sd_last_block_address = pxCSD->capacity - 1;
+
+		// compute card capacity in bytes
+		pxCSD->capacity_bytes = ( ( uint64_t )XSDPS_BLK_SIZE_512_MASK ) * pxCSD->capacity;
+
+		FF_PRINTF( "sd_mmc_spi_get_capacity: Capacity %lu MB Erase %u Pref %lu\n",
+			( uint32_t ) ( pxCSD->capacity_bytes / ( 1024LLU * 1024LLU ) ),
+			pxCSD->erase_size,
+			pxCSD->pref_erase );
+	}
+
+	return iResult;
+}

--- a/portable/Zynq.2019.3/xsdps_info.h
+++ b/portable/Zynq.2019.3/xsdps_info.h
@@ -1,0 +1,56 @@
+/******************************************************************************
+ *
+ * mmc_decode_cid() and sd_decode_csd()
+ *
+ * analyse the meta data of an SD-card to read its capacity and some other properties.
+ *
+ * CID and CSD Analysis borrowed from the Linux kernel.
+ *
+ ******************************************************************************/
+
+#ifndef SDPS_INFO_H_
+
+#define SDPS_INFO_H_  1
+
+#include <stdint.h>
+
+struct mmc_cid {
+	uint32_t	manfid;
+	char		prod_name[8];
+	uint32_t	serial;
+	uint16_t	oemid;
+	uint16_t	year;
+	uint8_t		hwrev;
+	uint8_t		fwrev;
+	uint8_t		month;
+};
+
+struct mmc_csd {
+	volatile uint64_t	capacity_bytes;
+	uint32_t	sd_last_block_address;
+	uint8_t		mmca_vsn;
+	uint16_t	erase_size;
+	uint8_t		spare;
+	uint16_t	cmdclass;
+	uint16_t	tacc_clks;
+	int32_t		erase_shift;
+	uint32_t	tacc_ns;
+	uint32_t	r2w_factor;
+	uint32_t	max_dtr;
+	uint32_t	read_blkbits;
+	uint32_t	write_blkbits;
+	uint32_t	capacity;
+	uint32_t	pref_erase;
+	uint32_t	read_partial : 1,
+				read_misalign : 1,
+				write_partial : 1,
+				write_misalign : 1;
+};
+
+extern struct mmc_cid myCID;
+extern struct mmc_csd myCSD;
+
+int mmc_decode_cid( const struct mmc_csd *pxCSD, struct mmc_cid *pxCID, uint32_t *raw_data );
+int sd_decode_csd( struct mmc_csd *pxCSD, uint32_t *ulResponse );
+
+#endif /* SDPS_INFO_H_ */

--- a/portable/Zynq.2019.3/xsdps_options.c
+++ b/portable/Zynq.2019.3/xsdps_options.c
@@ -1,0 +1,1469 @@
+/******************************************************************************
+*
+* Copyright (C) 2013 - 2019 Xilinx, Inc.  All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*
+*
+*
+******************************************************************************/
+/*****************************************************************************/
+/**
+*
+* @file xsdps_options.c
+* @addtogroup sdps_v3_8
+* @{
+*
+* Contains API's for changing the various options in host and card.
+* See xsdps.h for a detailed description of the device and driver.
+*
+* <pre>
+* MODIFICATION HISTORY:
+*
+* Ver   Who    Date     Changes
+* ----- ---    -------- -----------------------------------------------
+* 1.00a hk/sg  10/17/13 Initial release
+* 2.1   hk     04/18/14 Increase sleep for eMMC switch command.
+*                       Add sleep for microblaze designs. CR# 781117.
+* 2.3   sk     09/23/14 Use XSdPs_Change_ClkFreq API whenever changing
+*						clock.CR# 816586.
+* 2.5 	sg	   07/09/15 Added SD 3.0 features
+*       kvn    07/15/15 Modified the code according to MISRAC-2012.
+* 2.7   sk     01/08/16 Added workaround for issue in auto tuning mode
+*                       of SDR50, SDR104 and HS200.
+*       sk     02/16/16 Corrected the Tuning logic.
+*       sk     03/02/16 Configured the Tap Delay values for eMMC HS200 mode.
+* 2.8   sk     04/20/16 Added new workaround for auto tuning.
+* 3.0   sk     07/07/16 Used usleep API for both arm and microblaze.
+*       sk     07/16/16 Added support for UHS modes.
+*       sk     07/16/16 Added Tap delays accordingly to different SD/eMMC
+*                       operating modes.
+* 3.1   mi     09/07/16 Removed compilation warnings with extra compiler flags.
+*       sk     11/07/16 Enable Rst_n bit in ext_csd reg if not enabled.
+*       sk     11/16/16 Issue DLL reset at 31 iteration to load new zero value.
+* 3.2   sk     02/01/17 Added HSD and DDR mode support for eMMC.
+*       sk     02/01/17 Consider bus width parameter from design for switching
+*       vns    02/09/17 Added ARMA53_32 support for ZynqMP CR#968397
+*       vns    03/13/17 Fixed MISRAC mandatory violation
+*       sk     03/20/17 Add support for EL1 non-secure mode.
+* 3.3   mn     07/25/17 Removed SD0_OTAPDLYENA and SD1_OTAPDLYENA bits
+*       mn     08/07/17	Properly set OTAPDLY value by clearing previous bit
+* 			settings
+*       mn     08/17/17 Added CCI support for A53 and disabled data cache
+*                       operations when it is enabled.
+*       mn     08/22/17 Updated for Word Access System support
+* 3.4   mn     01/22/18 Separated out SDR104 and HS200 clock defines
+* 3.6   mn     07/06/18 Fix Cppcheck warnings for sdps driver
+* 3.7   aru    03/12/19 Modified the code according to MISRAC-2012.
+*       mn     03/27/19 Disable calls to dll_reset API for versal SPP Platforms
+* 3.8   mn     04/12/19 Modified TapDelay code for supporting ZynqMP and Versal
+*       mn     05/21/19 Set correct tap delays for Versal
+*       mn     05/21/19 Disable DLL Reset code for Versal
+*       mn     08/29/19 Add call to Cache Invalidation API in XSdPs_Get_BusWidth
+*
+* </pre>
+*
+******************************************************************************/
+
+/***************************** Include Files *********************************/
+#include "xsdps.h"
+#include "sleep.h"
+#if defined (__aarch64__)
+#include "xil_smc.h"
+#endif
+
+#include <FreeRTOS.h>
+#include "task.h"
+
+#include "FreeRTOSFATConfig.h"
+#include "uncached_memory.h"
+
+/************************** Constant Definitions *****************************/
+#define UHS_SDR12_SUPPORT	0x1U
+#define UHS_SDR25_SUPPORT	0x2U
+#define UHS_SDR50_SUPPORT	0x4U
+#define UHS_SDR104_SUPPORT	0x8U
+#define UHS_DDR50_SUPPORT	0x10U
+/**************************** Type Definitions *******************************/
+
+/***************** Macros (Inline Functions) Definitions *********************/
+
+/************************** Function Prototypes ******************************/
+s32 XSdPs_CmdTransfer(XSdPs *InstancePtr, u32 Cmd, u32 Arg, u32 BlkCnt);
+void XSdPs_SetupADMA2DescTbl(XSdPs *InstancePtr, u32 BlkCnt, const u8 *Buff);
+static s32 XSdPs_Execute_Tuning(XSdPs *InstancePtr);
+#if defined (ARMR5) || defined (__aarch64__) || defined (ARMA53_32) || defined (__MICROBLAZE__)
+s32 XSdPs_Uhs_ModeInit(XSdPs *InstancePtr, u8 Mode);
+void XSdPs_SetTapDelay(XSdPs *InstancePtr);
+#ifndef versal
+static void XSdPs_DllReset(XSdPs *InstancePtr);
+#endif
+#endif
+
+extern u16 TransferMode;
+/*****************************************************************************/
+/**
+* Update Block size for read/write operations.
+*
+* @param	InstancePtr is a pointer to the instance to be worked on.
+* @param	BlkSize - Block size passed by the user.
+*
+* @return	None
+*
+******************************************************************************/
+s32 XSdPs_SetBlkSize(XSdPs *InstancePtr, u16 BlkSize)
+{
+	s32 Status;
+	u32 PresentStateReg;
+
+	Xil_AssertNonvoid(InstancePtr != NULL);
+	Xil_AssertNonvoid(InstancePtr->IsReady == XIL_COMPONENT_IS_READY);
+
+	PresentStateReg = XSdPs_ReadReg(InstancePtr->Config.BaseAddress,
+			XSDPS_PRES_STATE_OFFSET);
+
+	if ((PresentStateReg & ((u32)XSDPS_PSR_INHIBIT_CMD_MASK |
+			(u32)XSDPS_PSR_INHIBIT_DAT_MASK |
+			(u32)XSDPS_PSR_WR_ACTIVE_MASK | (u32)XSDPS_PSR_RD_ACTIVE_MASK)) != 0U) {
+		Status = XST_FAILURE;
+		goto RETURN_PATH;
+	}
+
+
+	/* Send block write command */
+	Status = XSdPs_CmdTransfer(InstancePtr, CMD16, BlkSize, 0U);
+	if (Status != XST_SUCCESS) {
+		Status = XST_FAILURE;
+		goto RETURN_PATH;
+	}
+
+	/* Set block size to the value passed */
+	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress, XSDPS_BLK_SIZE_OFFSET,
+			 BlkSize & XSDPS_BLK_SIZE_MASK);
+
+	Status = XST_SUCCESS;
+
+	RETURN_PATH:
+		return Status;
+
+}
+
+/*****************************************************************************/
+/**
+*
+* API to get bus width support by card.
+*
+*
+* @param	InstancePtr is a pointer to the XSdPs instance.
+* @param	SCR - buffer to store SCR register returned by card.
+*
+* @return
+*		- XST_SUCCESS if successful.
+*		- XST_FAILURE if fail.
+*
+* @note		None.
+*
+******************************************************************************/
+s32 XSdPs_Get_BusWidth(XSdPs *InstancePtr, u8 *SCR)
+{
+	s32 Status;
+	u32 StatusReg;
+	u16 BlkCnt;
+	u16 BlkSize;
+	s32 LoopCnt;
+
+	Xil_AssertNonvoid(InstancePtr != NULL);
+	Xil_AssertNonvoid(InstancePtr->IsReady == XIL_COMPONENT_IS_READY);
+
+	for (LoopCnt = 0; LoopCnt < 8; LoopCnt++) {
+		SCR[LoopCnt] = 0U;
+	}
+
+	/* Send block write command */
+	Status = XSdPs_CmdTransfer(InstancePtr, CMD55,
+			InstancePtr->RelCardAddr, 0U);
+	if (Status != XST_SUCCESS) {
+		Status = XST_FAILURE;
+		goto RETURN_PATH;
+	}
+
+	BlkCnt = XSDPS_SCR_BLKCNT;
+	BlkSize = XSDPS_SCR_BLKSIZE;
+
+	/* Set block size to the value passed */
+	BlkSize &= XSDPS_BLK_SIZE_MASK;
+	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_BLK_SIZE_OFFSET, BlkSize);
+
+	XSdPs_SetupADMA2DescTbl(InstancePtr, BlkCnt, SCR);
+
+	TransferMode = 	XSDPS_TM_DAT_DIR_SEL_MASK | XSDPS_TM_DMA_EN_MASK;
+
+	if (ucIsCachedMemory( SCR )) {
+		Xil_DCacheInvalidateRange((INTPTR)SCR, 8);
+	}
+
+	Status = XSdPs_CmdTransfer(InstancePtr, ACMD51, 0U, BlkCnt);
+	if (Status != XST_SUCCESS) {
+		Status = XST_FAILURE;
+		goto RETURN_PATH;
+	}
+
+	/*
+	 * Check for transfer complete
+	 */
+	Status = XSdPs_Wait_For(InstancePtr, XSDPS_INTR_TC_MASK, pdTRUE);
+	if (Status != XST_SUCCESS) {
+		goto RETURN_PATH;
+	}
+
+	Status = (s32)XSdPs_ReadReg(InstancePtr->Config.BaseAddress,
+			XSDPS_RESP0_OFFSET);
+
+	Status = XST_SUCCESS;
+
+	RETURN_PATH:
+		return Status;
+
+}
+
+/*****************************************************************************/
+/**
+*
+* API to set bus width to 4-bit in card and host
+*
+*
+* @param	InstancePtr is a pointer to the XSdPs instance.
+*
+* @return
+*		- XST_SUCCESS if successful.
+*		- XST_FAILURE if fail.
+*
+* @note		None.
+*
+******************************************************************************/
+s32 XSdPs_Change_BusWidth(XSdPs *InstancePtr)
+{
+	s32 Status;
+	u32 StatusReg;
+	u32 Arg;
+
+	Xil_AssertNonvoid(InstancePtr != NULL);
+	Xil_AssertNonvoid(InstancePtr->IsReady == XIL_COMPONENT_IS_READY);
+
+
+	/*
+	 * check for bus width for 3.0 controller and return if
+	 * bus width is <4
+	 */
+	if ((InstancePtr->HC_Version == XSDPS_HC_SPEC_V3) &&
+			(InstancePtr->Config.BusWidth < XSDPS_WIDTH_4)) {
+		Status = XST_SUCCESS;
+		goto RETURN_PATH;
+	}
+
+	if (InstancePtr->CardType == XSDPS_CARD_SD) {
+
+		Status = XSdPs_CmdTransfer(InstancePtr, CMD55, InstancePtr->RelCardAddr,
+				0U);
+		if (Status != XST_SUCCESS) {
+			Status = XST_FAILURE;
+			goto RETURN_PATH;
+		}
+
+		InstancePtr->BusWidth = XSDPS_4_BIT_WIDTH;
+
+		Arg = ((u32)InstancePtr->BusWidth);
+
+		Status = XSdPs_CmdTransfer(InstancePtr, ACMD6, Arg, 0U);
+		if (Status != XST_SUCCESS) {
+			Status = XST_FAILURE;
+			goto RETURN_PATH;
+		}
+	} else {
+
+		if ((InstancePtr->HC_Version == XSDPS_HC_SPEC_V3)
+				&& (InstancePtr->CardType == XSDPS_CHIP_EMMC) &&
+				(InstancePtr->Config.BusWidth == XSDPS_WIDTH_8)) {
+			/* in case of eMMC data width 8-bit */
+			InstancePtr->BusWidth = XSDPS_8_BIT_WIDTH;
+		} else {
+			InstancePtr->BusWidth = XSDPS_4_BIT_WIDTH;
+		}
+
+		if (InstancePtr->BusWidth == XSDPS_8_BIT_WIDTH) {
+			if (InstancePtr->Mode == XSDPS_DDR52_MODE) {
+				Arg = XSDPS_MMC_DDR_8_BIT_BUS_ARG;
+			} else {
+				Arg = XSDPS_MMC_8_BIT_BUS_ARG;
+			}
+		} else {
+			if (InstancePtr->Mode == XSDPS_DDR52_MODE) {
+				Arg = XSDPS_MMC_DDR_4_BIT_BUS_ARG;
+			} else {
+				Arg = XSDPS_MMC_4_BIT_BUS_ARG;
+			}
+		}
+
+		Status = XSdPs_CmdTransfer(InstancePtr, CMD6, Arg, 0U);
+		if (Status != XST_SUCCESS) {
+			Status = XST_FAILURE;
+			goto RETURN_PATH;
+		}
+
+		/* Check for transfer complete */
+		Status = XSdPs_Wait_For(InstancePtr, XSDPS_INTR_TC_MASK, pdTRUE);
+		if (Status != XST_SUCCESS) {
+			goto RETURN_PATH;
+		}
+	}
+
+	usleep(XSDPS_MMC_DELAY_FOR_SWITCH);
+
+	StatusReg = XSdPs_ReadReg8(InstancePtr->Config.BaseAddress,
+					XSDPS_HOST_CTRL1_OFFSET);
+
+	/* Width setting in controller */
+	if (InstancePtr->BusWidth == XSDPS_8_BIT_WIDTH) {
+		StatusReg |= XSDPS_HC_EXT_BUS_WIDTH;
+	} else {
+		StatusReg |= XSDPS_HC_WIDTH_MASK;
+	}
+
+	XSdPs_WriteReg8(InstancePtr->Config.BaseAddress,
+			XSDPS_HOST_CTRL1_OFFSET,
+			(u8)StatusReg);
+
+	if (InstancePtr->Mode == XSDPS_DDR52_MODE) {
+		StatusReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+					XSDPS_HOST_CTRL2_OFFSET);
+		StatusReg &= (u32)(~XSDPS_HC2_UHS_MODE_MASK);
+		StatusReg |= InstancePtr->Mode;
+		XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+					XSDPS_HOST_CTRL2_OFFSET, (u16)StatusReg);
+	}
+
+	Status = XST_SUCCESS;
+
+	RETURN_PATH:
+		return Status;
+
+}
+
+/*****************************************************************************/
+/**
+*
+* API to get bus speed supported by card.
+*
+*
+* @param	InstancePtr is a pointer to the XSdPs instance.
+* @param	ReadBuff - buffer to store function group support data
+*		returned by card.
+*
+* @return
+*		- XST_SUCCESS if successful.
+*		- XST_FAILURE if fail.
+*
+* @note		None.
+*
+******************************************************************************/
+s32 XSdPs_Get_BusSpeed(XSdPs *InstancePtr, u8 *ReadBuff)
+{
+	s32 Status;
+	u32 StatusReg;
+	u32 Arg;
+	u16 BlkCnt;
+	u16 BlkSize;
+	s32 LoopCnt;
+
+	Xil_AssertNonvoid(InstancePtr != NULL);
+	Xil_AssertNonvoid(InstancePtr->IsReady == XIL_COMPONENT_IS_READY);
+
+	for (LoopCnt = 0; LoopCnt < 64; LoopCnt++) {
+		ReadBuff[LoopCnt] = 0U;
+	}
+
+	BlkCnt = XSDPS_SWITCH_CMD_BLKCNT;
+	BlkSize = XSDPS_SWITCH_CMD_BLKSIZE;
+	BlkSize &= XSDPS_BLK_SIZE_MASK;
+	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_BLK_SIZE_OFFSET, BlkSize);
+
+	XSdPs_SetupADMA2DescTbl(InstancePtr, BlkCnt, ReadBuff);
+
+	TransferMode = 	XSDPS_TM_DAT_DIR_SEL_MASK | XSDPS_TM_DMA_EN_MASK;
+
+	Arg = XSDPS_SWITCH_CMD_HS_GET;
+
+	if ( ucIsCachedMemory( ReadBuff ) ) {
+		Xil_DCacheInvalidateRange((INTPTR)ReadBuff, 64);
+	}
+
+	Status = XSdPs_CmdTransfer(InstancePtr, CMD6, Arg, 1U);
+	if (Status != XST_SUCCESS) {
+		Status = XST_FAILURE;
+		goto RETURN_PATH;
+	}
+
+	/*
+	 * Check for transfer complete
+	 */
+	Status = XSdPs_Wait_For(InstancePtr, XSDPS_INTR_TC_MASK, pdTRUE);
+	if (Status != XST_SUCCESS) {
+		goto RETURN_PATH;
+	}
+
+	Status = (s32)XSdPs_ReadReg(InstancePtr->Config.BaseAddress,
+			XSDPS_RESP0_OFFSET);
+
+	Status = XST_SUCCESS;
+
+	RETURN_PATH:
+		return Status;
+
+}
+
+/*****************************************************************************/
+/**
+*
+* API to get SD card status information.
+*
+*
+* @param	InstancePtr is a pointer to the XSdPs instance.
+* @param	SdStatReg - buffer to store status data returned by card.
+*
+* @return
+*		- XST_SUCCESS if successful.
+*		- XST_FAILURE if fail.
+*
+* @note		None.
+*
+******************************************************************************/
+s32 XSdPs_Get_Status(XSdPs *InstancePtr, u8 *SdStatReg)
+{
+	s32 Status;
+	u32 StatusReg;
+	u16 BlkCnt;
+	u16 BlkSize;
+
+	Xil_AssertNonvoid(InstancePtr != NULL);
+	Xil_AssertNonvoid(InstancePtr->IsReady == XIL_COMPONENT_IS_READY);
+
+	/* Send block write command */
+	Status = XSdPs_CmdTransfer(InstancePtr, CMD55,
+			InstancePtr->RelCardAddr, 0U);
+	if (Status != XST_SUCCESS) {
+		Status = XST_FAILURE;
+		goto RETURN_PATH;
+	}
+
+	BlkCnt = 1;
+	BlkSize = 64;
+
+	/* Set block size to the value passed */
+	BlkSize &= XSDPS_BLK_SIZE_MASK;
+	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_BLK_SIZE_OFFSET, BlkSize);
+
+	XSdPs_SetupADMA2DescTbl(InstancePtr, BlkCnt, SdStatReg);
+
+	TransferMode = 	XSDPS_TM_DAT_DIR_SEL_MASK | XSDPS_TM_DMA_EN_MASK;
+
+	if ( ucIsCachedMemory( SdStatReg ) ) {
+		Xil_DCacheInvalidateRange((INTPTR)SdStatReg, 64);
+	}
+
+	Status = XSdPs_CmdTransfer(InstancePtr, ACMD13, 0U, BlkCnt);
+	if (Status != XST_SUCCESS) {
+		Status = XST_FAILURE;
+		goto RETURN_PATH;
+	}
+
+	/*
+	 * Check for transfer complete
+	 */
+	Status = XSdPs_Wait_For(InstancePtr, XSDPS_INTR_TC_MASK, pdTRUE);
+	if (Status != XST_SUCCESS) {
+		goto RETURN_PATH;
+	}
+
+	if ( ucIsCachedMemory( SdStatReg ) ) {
+		Xil_DCacheInvalidateRange((INTPTR)SdStatReg, 64U);
+	}
+
+	Status = XST_SUCCESS;
+
+	RETURN_PATH:
+		return Status;
+}
+
+/*****************************************************************************/
+/**
+*
+* API to set high speed in card and host. Changes clock in host accordingly.
+*
+*
+* @param	InstancePtr is a pointer to the XSdPs instance.
+*
+* @return
+*		- XST_SUCCESS if successful.
+*		- XST_FAILURE if fail.
+*
+* @note		None.
+*
+******************************************************************************/
+s32 XSdPs_Change_BusSpeed(XSdPs *InstancePtr)
+{
+	s32 Status;
+	u32 StatusReg;
+	u32 Arg;
+	u16 BlkCnt;
+	u16 BlkSize;
+	u8 ReadBuff[64] = {0U};
+
+	Xil_AssertNonvoid(InstancePtr != NULL);
+	Xil_AssertNonvoid(InstancePtr->IsReady == XIL_COMPONENT_IS_READY);
+
+	if (InstancePtr->CardType == XSDPS_CARD_SD) {
+
+		BlkCnt = XSDPS_SWITCH_CMD_BLKCNT;
+		BlkSize = XSDPS_SWITCH_CMD_BLKSIZE;
+		BlkSize &= XSDPS_BLK_SIZE_MASK;
+		XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+				XSDPS_BLK_SIZE_OFFSET, BlkSize);
+
+		XSdPs_SetupADMA2DescTbl(InstancePtr, BlkCnt, ReadBuff);
+
+		if (InstancePtr->Config.IsCacheCoherent == 0U) {
+			Xil_DCacheFlushRange((INTPTR)ReadBuff, 64);
+		}
+
+		TransferMode = 	XSDPS_TM_DAT_DIR_SEL_MASK | XSDPS_TM_DMA_EN_MASK;
+
+		Arg = XSDPS_SWITCH_CMD_HS_SET;
+
+		Status = XSdPs_CmdTransfer(InstancePtr, CMD6, Arg, 1U);
+		if (Status != XST_SUCCESS) {
+			Status = XST_FAILURE;
+			goto RETURN_PATH;
+		}
+
+		/*
+		 * Check for transfer complete
+		 */
+		Status = XSdPs_Wait_For(InstancePtr, XSDPS_INTR_TC_MASK, pdTRUE);
+		if (Status != XST_SUCCESS) {
+			goto RETURN_PATH;
+		}
+
+		/* Change the clock frequency to 50 MHz */
+		InstancePtr->BusSpeed = XSDPS_CLK_50_MHZ;
+		Status = XSdPs_Change_ClkFreq(InstancePtr, InstancePtr->BusSpeed);
+		if (Status != XST_SUCCESS) {
+				Status = XST_FAILURE;
+				goto RETURN_PATH;
+		}
+
+	} else if (InstancePtr->CardType == XSDPS_CARD_MMC) {
+		Arg = XSDPS_MMC_HIGH_SPEED_ARG;
+
+		Status = XSdPs_CmdTransfer(InstancePtr, CMD6, Arg, 0U);
+		if (Status != XST_SUCCESS) {
+			Status = XST_FAILURE;
+			goto RETURN_PATH;
+		}
+
+		/*
+		 * Check for transfer complete
+		 */
+		Status = XSdPs_Wait_For(InstancePtr, XSDPS_INTR_TC_MASK, pdTRUE);
+		if (Status != XST_SUCCESS) {
+			goto RETURN_PATH;
+		}
+
+		/* Change the clock frequency to 52 MHz */
+		InstancePtr->BusSpeed = XSDPS_CLK_52_MHZ;
+		Status = XSdPs_Change_ClkFreq(InstancePtr, XSDPS_CLK_52_MHZ);
+		if (Status != XST_SUCCESS) {
+			Status = XST_FAILURE;
+			goto RETURN_PATH;
+		}
+	} else {
+		if (InstancePtr->Mode == XSDPS_HS200_MODE) {
+			Arg = XSDPS_MMC_HS200_ARG;
+			InstancePtr->BusSpeed = XSDPS_MMC_HS200_MAX_CLK;
+		} else if (InstancePtr->Mode == XSDPS_DDR52_MODE) {
+			Arg = XSDPS_MMC_HIGH_SPEED_ARG;
+			InstancePtr->BusSpeed = XSDPS_MMC_DDR_MAX_CLK;
+		} else {
+			Arg = XSDPS_MMC_HIGH_SPEED_ARG;
+			InstancePtr->BusSpeed = XSDPS_MMC_HSD_MAX_CLK;
+		}
+
+		Status = XSdPs_CmdTransfer(InstancePtr, CMD6, Arg, 0U);
+		if (Status != XST_SUCCESS) {
+			Status = XST_FAILURE;
+			goto RETURN_PATH;
+		}
+
+		/*
+		 * Check for transfer complete
+		 */
+		Status = XSdPs_Wait_For(InstancePtr, XSDPS_INTR_TC_MASK, pdTRUE);
+		if (Status != XST_SUCCESS) {
+			goto RETURN_PATH;
+		}
+
+		Status = XSdPs_Change_ClkFreq(InstancePtr, InstancePtr->BusSpeed);
+		if (Status != XST_SUCCESS) {
+			Status = XST_FAILURE;
+			goto RETURN_PATH;
+		}
+
+		if (InstancePtr->Mode == XSDPS_HS200_MODE) {
+			Status = XSdPs_Execute_Tuning(InstancePtr);
+			if (Status != XST_SUCCESS) {
+				Status = XST_FAILURE;
+				goto RETURN_PATH;
+			}
+		}
+	}
+
+	usleep(XSDPS_MMC_DELAY_FOR_SWITCH);
+
+	StatusReg = (u32)XSdPs_ReadReg8(InstancePtr->Config.BaseAddress,
+					XSDPS_HOST_CTRL1_OFFSET);
+	StatusReg |= XSDPS_HC_SPEED_MASK;
+	XSdPs_WriteReg8(InstancePtr->Config.BaseAddress,
+			XSDPS_HOST_CTRL1_OFFSET, (u8)StatusReg);
+
+	Status = XST_SUCCESS;
+
+	RETURN_PATH:
+		return Status;
+
+}
+
+/*****************************************************************************/
+/**
+*
+* API to change clock freq to given value.
+*
+*
+* @param	InstancePtr is a pointer to the XSdPs instance.
+* @param	SelFreq - Clock frequency in Hz.
+*
+* @return	None
+*
+* @note		This API will change clock frequency to the value less than
+*		or equal to the given value using the permissible dividors.
+*
+******************************************************************************/
+s32 XSdPs_Change_ClkFreq(XSdPs *InstancePtr, u32 SelFreq)
+{
+	u16 ClockReg;
+	u16 DivCnt;
+	u16 Divisor = 0U;
+	u16 ExtDivisor;
+	s32 Status;
+	u16 ReadReg;
+
+	Xil_AssertNonvoid(InstancePtr != NULL);
+	Xil_AssertNonvoid(InstancePtr->IsReady == XIL_COMPONENT_IS_READY);
+
+	/* Disable clock */
+	ClockReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_CLK_CTRL_OFFSET);
+	ClockReg &= ~(XSDPS_CC_SD_CLK_EN_MASK | XSDPS_CC_INT_CLK_EN_MASK);
+	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_CLK_CTRL_OFFSET, ClockReg);
+
+	if (InstancePtr->HC_Version == XSDPS_HC_SPEC_V3) {
+#if defined (ARMR5) || defined (__aarch64__) || defined (ARMA53_32) || defined (__MICROBLAZE__)
+	if ((InstancePtr->Mode != XSDPS_DEFAULT_SPEED_MODE) &&
+			(InstancePtr->Mode != XSDPS_UHS_SPEED_MODE_SDR12)) {
+		/* Program the Tap delays */
+		XSdPs_SetTapDelay(InstancePtr);
+	}
+#endif
+		/* Calculate divisor */
+		for (DivCnt = 0x1U; DivCnt <= XSDPS_CC_EXT_MAX_DIV_CNT;DivCnt++) {
+			if (((InstancePtr->Config.InputClockHz) / DivCnt) <= SelFreq) {
+				Divisor = DivCnt >> 1;
+				break;
+			}
+		}
+
+		if (DivCnt > XSDPS_CC_EXT_MAX_DIV_CNT) {
+			/* No valid divisor found for given frequency */
+			Status = XST_FAILURE;
+			goto RETURN_PATH;
+		}
+	} else {
+		/* Calculate divisor */
+		DivCnt = 0x1U;
+		while (DivCnt <= XSDPS_CC_MAX_DIV_CNT) {
+			if (((InstancePtr->Config.InputClockHz) / DivCnt) <= SelFreq) {
+				Divisor = DivCnt / 2U;
+				break;
+			}
+			DivCnt = DivCnt << 1U;
+		}
+
+		if (DivCnt > XSDPS_CC_MAX_DIV_CNT) {
+			/* No valid divisor found for given frequency */
+			Status = XST_FAILURE;
+			goto RETURN_PATH;
+		}
+	}
+
+	/* Set clock divisor */
+	if (InstancePtr->HC_Version == XSDPS_HC_SPEC_V3) {
+		ClockReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+				XSDPS_CLK_CTRL_OFFSET);
+		ClockReg &= ~(XSDPS_CC_SDCLK_FREQ_SEL_MASK |
+		XSDPS_CC_SDCLK_FREQ_SEL_EXT_MASK);
+
+		ExtDivisor = Divisor >> 8;
+		ExtDivisor <<= XSDPS_CC_EXT_DIV_SHIFT;
+		ExtDivisor &= XSDPS_CC_SDCLK_FREQ_SEL_EXT_MASK;
+
+		Divisor <<= XSDPS_CC_DIV_SHIFT;
+		Divisor &= XSDPS_CC_SDCLK_FREQ_SEL_MASK;
+		ClockReg |= Divisor | ExtDivisor | (u16)XSDPS_CC_INT_CLK_EN_MASK;
+		XSdPs_WriteReg16(InstancePtr->Config.BaseAddress, XSDPS_CLK_CTRL_OFFSET,
+				ClockReg);
+	} else {
+		ClockReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+				XSDPS_CLK_CTRL_OFFSET);
+		ClockReg &= (~XSDPS_CC_SDCLK_FREQ_SEL_MASK);
+
+		Divisor <<= XSDPS_CC_DIV_SHIFT;
+		Divisor &= XSDPS_CC_SDCLK_FREQ_SEL_MASK;
+		ClockReg |= Divisor | (u16)XSDPS_CC_INT_CLK_EN_MASK;
+		XSdPs_WriteReg16(InstancePtr->Config.BaseAddress, XSDPS_CLK_CTRL_OFFSET,
+				ClockReg);
+	}
+
+	/* Wait for internal clock to stabilize */
+	ReadReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+				XSDPS_CLK_CTRL_OFFSET);
+	while((ReadReg & XSDPS_CC_INT_CLK_STABLE_MASK) == 0U) {
+		ReadReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+					XSDPS_CLK_CTRL_OFFSET);;
+	}
+
+	/* Enable SD clock */
+	ClockReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_CLK_CTRL_OFFSET);
+	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_CLK_CTRL_OFFSET,
+			ClockReg | XSDPS_CC_SD_CLK_EN_MASK);
+
+	Status = XST_SUCCESS;
+
+RETURN_PATH:
+		return Status;
+
+}
+
+/*****************************************************************************/
+/**
+*
+* API to send pullup command to card before using DAT line 3(using 4-bit bus)
+*
+*
+* @param	InstancePtr is a pointer to the XSdPs instance.
+*
+* @return
+*		- XST_SUCCESS if successful.
+*		- XST_FAILURE if fail.
+*
+* @note		None.
+*
+******************************************************************************/
+s32 XSdPs_Pullup(XSdPs *InstancePtr)
+{
+	s32 Status;
+
+	Xil_AssertNonvoid(InstancePtr != NULL);
+	Xil_AssertNonvoid(InstancePtr->IsReady == XIL_COMPONENT_IS_READY);
+
+	Status = XSdPs_CmdTransfer(InstancePtr, CMD55,
+			InstancePtr->RelCardAddr, 0U);
+	if (Status != XST_SUCCESS) {
+		Status = XST_FAILURE;
+		goto RETURN_PATH;
+	}
+
+	Status = XSdPs_CmdTransfer(InstancePtr, ACMD42, 0U, 0U);
+	if (Status != XST_SUCCESS) {
+		Status = XST_FAILURE;
+		goto RETURN_PATH;
+	}
+
+	Status = XST_SUCCESS;
+
+	RETURN_PATH:
+		return Status;
+
+}
+
+/*****************************************************************************/
+/**
+*
+* API to get EXT_CSD register of eMMC.
+*
+*
+* @param	InstancePtr is a pointer to the XSdPs instance.
+* @param	ReadBuff - buffer to store EXT_CSD
+*
+* @return
+*		- XST_SUCCESS if successful.
+*		- XST_FAILURE if fail.
+*
+* @note		None.
+*
+******************************************************************************/
+s32 XSdPs_Get_Mmc_ExtCsd(XSdPs *InstancePtr, u8 *ReadBuff)
+{
+	s32 Status;
+	u32 StatusReg;
+	u32 Arg = 0U;
+	u16 BlkCnt;
+	u16 BlkSize;
+	s32 LoopCnt;
+
+	Xil_AssertNonvoid(InstancePtr != NULL);
+	Xil_AssertNonvoid(InstancePtr->IsReady == XIL_COMPONENT_IS_READY);
+
+	for (LoopCnt = 0; LoopCnt < 512; LoopCnt++) {
+		ReadBuff[LoopCnt] = 0U;
+	}
+
+	BlkCnt = XSDPS_EXT_CSD_CMD_BLKCNT;
+	BlkSize = XSDPS_EXT_CSD_CMD_BLKSIZE;
+	BlkSize &= XSDPS_BLK_SIZE_MASK;
+	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_BLK_SIZE_OFFSET, BlkSize);
+
+	XSdPs_SetupADMA2DescTbl(InstancePtr, BlkCnt, ReadBuff);
+
+	if ( ucIsCachedMemory( ReadBuff ) ) {
+		Xil_DCacheInvalidateRange((INTPTR)ReadBuff, 512U);
+	}
+
+	TransferMode = 	XSDPS_TM_DAT_DIR_SEL_MASK | XSDPS_TM_DMA_EN_MASK;
+
+	/* Send SEND_EXT_CSD command */
+	Status = XSdPs_CmdTransfer(InstancePtr, CMD8, Arg, 1U);
+	if (Status != XST_SUCCESS) {
+		Status = XST_FAILURE;
+		goto RETURN_PATH;
+	}
+
+	/*
+	 * Check for transfer complete
+	 */
+	Status = XSdPs_Wait_For(InstancePtr, XSDPS_INTR_TC_MASK, pdTRUE);
+	if (Status != XST_SUCCESS) {
+		goto RETURN_PATH;
+	}
+
+	if ( ucIsCachedMemory( ReadBuff ) ) {
+		Xil_DCacheInvalidateRange((INTPTR)ReadBuff, 512U);
+	}
+
+	Status = XST_SUCCESS;
+
+	RETURN_PATH:
+		return Status;
+
+}
+
+/*****************************************************************************/
+/**
+*
+* API to write EXT_CSD register of eMMC.
+*
+*
+* @param	InstancePtr is a pointer to the XSdPs instance.
+* @param	Arg is the argument to be sent along with the command
+*
+* @return
+*		- XST_SUCCESS if successful.
+*		- XST_FAILURE if fail.
+*
+* @note		None.
+*
+******************************************************************************/
+s32 XSdPs_Set_Mmc_ExtCsd(XSdPs *InstancePtr, u32 Arg)
+{
+	s32 Status;
+	u32 StatusReg;
+
+	Status = XSdPs_CmdTransfer(InstancePtr, CMD6, Arg, 0U);
+	if (Status != XST_SUCCESS) {
+		Status = XST_FAILURE;
+		goto RETURN_PATH;
+	}
+
+	/*
+	 * Check for transfer complete
+	 */
+	Status = XSdPs_Wait_For(InstancePtr, XSDPS_INTR_TC_MASK, pdTRUE);
+	if (Status != XST_SUCCESS) {
+		goto RETURN_PATH;
+	}
+
+	Status = XST_SUCCESS;
+
+	RETURN_PATH:
+		return Status;
+
+}
+
+#if defined (ARMR5) || defined (__aarch64__) || defined (ARMA53_32) || defined (__MICROBLAZE__)
+/*****************************************************************************/
+/**
+*
+* API to Identify the supported UHS mode. This API will assign the
+* corresponding tap delay API to the Config_TapDelay pointer based on the
+* supported bus speed.
+*
+*
+* @param	InstancePtr is a pointer to the XSdPs instance.
+* @param	ReadBuff contains the response for CMD6
+*
+* @return	None.
+*
+* @note		None.
+*
+******************************************************************************/
+void XSdPs_Identify_UhsMode(XSdPs *InstancePtr, u8 *ReadBuff)
+{
+
+	Xil_AssertVoid(InstancePtr != NULL);
+
+	if (((ReadBuff[13] & UHS_SDR104_SUPPORT) != 0U) &&
+		(InstancePtr->Config.InputClockHz >= XSDPS_SD_INPUT_MAX_CLK)) {
+		InstancePtr->Mode = XSDPS_UHS_SPEED_MODE_SDR104;
+		if (InstancePtr->Config.BankNumber == 2U) {
+			InstancePtr->OTapDelay = SD_OTAPDLYSEL_HS200_B2;
+		} else {
+			InstancePtr->OTapDelay = SD_OTAPDLYSEL_HS200_B0;
+		}
+	} else if (((ReadBuff[13] & UHS_SDR50_SUPPORT) != 0U) &&
+		(InstancePtr->Config.InputClockHz >= XSDPS_SD_SDR50_MAX_CLK)) {
+		InstancePtr->Mode = XSDPS_UHS_SPEED_MODE_SDR50;
+		InstancePtr->OTapDelay = SD_OTAPDLYSEL_SD50;
+	} else if (((ReadBuff[13] & UHS_DDR50_SUPPORT) != 0U) &&
+		(InstancePtr->Config.InputClockHz >= XSDPS_SD_DDR50_MAX_CLK)) {
+		InstancePtr->Mode = XSDPS_UHS_SPEED_MODE_DDR50;
+		InstancePtr->OTapDelay = SD_OTAPDLYSEL_SD_DDR50;
+		InstancePtr->ITapDelay = SD_ITAPDLYSEL_SD_DDR50;
+	} else if (((ReadBuff[13] & UHS_SDR25_SUPPORT) != 0U) &&
+		(InstancePtr->Config.InputClockHz >= XSDPS_SD_SDR25_MAX_CLK)) {
+		InstancePtr->Mode = XSDPS_UHS_SPEED_MODE_SDR25;
+		InstancePtr->OTapDelay = SD_OTAPDLYSEL_SD_HSD;
+		InstancePtr->ITapDelay = SD_ITAPDLYSEL_HSD;
+	} else {
+		InstancePtr->Mode = XSDPS_UHS_SPEED_MODE_SDR12;
+	}
+}
+
+/*****************************************************************************/
+/**
+*
+* API to UHS-I mode initialization
+*
+*
+* @param	InstancePtr is a pointer to the XSdPs instance.
+* @param	Mode UHS-I mode
+*
+* @return
+*		- XST_SUCCESS if successful.
+*		- XST_FAILURE if fail.
+*
+* @note		None.
+*
+******************************************************************************/
+s32 XSdPs_Uhs_ModeInit(XSdPs *InstancePtr, u8 Mode)
+{
+	s32 Status = XST_SUCCESS;
+	u16 StatusReg;
+	u16 CtrlReg;
+	u32 Arg = 0U;
+	u16 BlkCnt;
+	u16 BlkSize;
+	u8 ReadBuff[64] = {0U};
+
+	Xil_AssertNonvoid(InstancePtr != NULL);
+	Xil_AssertNonvoid(InstancePtr->IsReady == XIL_COMPONENT_IS_READY);
+
+	/* Drive strength */
+
+	/* Bus speed mode selection */
+	BlkCnt = XSDPS_SWITCH_CMD_BLKCNT;
+	BlkSize = XSDPS_SWITCH_CMD_BLKSIZE;
+	BlkSize &= XSDPS_BLK_SIZE_MASK;
+	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress, XSDPS_BLK_SIZE_OFFSET,
+			BlkSize);
+
+	XSdPs_SetupADMA2DescTbl(InstancePtr, BlkCnt, ReadBuff);
+
+	if (InstancePtr->Config.IsCacheCoherent == 0U) {
+		Xil_DCacheFlushRange((INTPTR)ReadBuff, 64);
+	}
+
+	TransferMode = 	XSDPS_TM_DAT_DIR_SEL_MASK | XSDPS_TM_DMA_EN_MASK;
+
+	switch (Mode) {
+	case 0U:
+		Arg = XSDPS_SWITCH_CMD_SDR12_SET;
+		InstancePtr->BusSpeed = XSDPS_SD_SDR12_MAX_CLK;
+		break;
+	case 1U:
+		Arg = XSDPS_SWITCH_CMD_SDR25_SET;
+		InstancePtr->BusSpeed = XSDPS_SD_SDR25_MAX_CLK;
+		break;
+	case 2U:
+		Arg = XSDPS_SWITCH_CMD_SDR50_SET;
+		InstancePtr->BusSpeed = XSDPS_SD_SDR50_MAX_CLK;
+		break;
+	case 3U:
+		Arg = XSDPS_SWITCH_CMD_SDR104_SET;
+		InstancePtr->BusSpeed = XSDPS_SD_SDR104_MAX_CLK;
+		break;
+	case 4U:
+		Arg = XSDPS_SWITCH_CMD_DDR50_SET;
+		InstancePtr->BusSpeed = XSDPS_SD_DDR50_MAX_CLK;
+		break;
+	default:
+		Status = XST_FAILURE;
+		break;
+	}
+
+	if (Status == XST_FAILURE) {
+		goto RETURN_PATH;
+	}
+
+	Status = XSdPs_CmdTransfer(InstancePtr, CMD6, Arg, 1U);
+	if (Status != XST_SUCCESS) {
+		Status = XST_FAILURE;
+		goto RETURN_PATH;
+	}
+
+	/*
+	 * Check for transfer complete
+	 */
+	Status = XSdPs_Wait_For(InstancePtr, XSDPS_INTR_TC_MASK, pdTRUE);
+	if (Status != XST_SUCCESS) {
+		goto RETURN_PATH;
+	}
+
+	/* Current limit */
+
+	/* Set UHS mode in controller */
+	CtrlReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_HOST_CTRL2_OFFSET);
+	CtrlReg &= (u16)(~XSDPS_HC2_UHS_MODE_MASK);
+	CtrlReg |= Mode;
+	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_HOST_CTRL2_OFFSET, CtrlReg);
+
+	/* Change the clock frequency */
+	Status = XSdPs_Change_ClkFreq(InstancePtr, InstancePtr->BusSpeed);
+	if (Status != XST_SUCCESS) {
+			Status = XST_FAILURE;
+			goto RETURN_PATH;
+	}
+
+	if((Mode == XSDPS_UHS_SPEED_MODE_SDR104) ||
+			(Mode == XSDPS_UHS_SPEED_MODE_SDR50)) {
+		/* Send tuning pattern */
+		Status = XSdPs_Execute_Tuning(InstancePtr);
+		if (Status != XST_SUCCESS) {
+				Status = XST_FAILURE;
+				goto RETURN_PATH;
+		}
+	}
+
+	Status = XST_SUCCESS;
+
+	RETURN_PATH:
+		return Status;
+}
+#endif
+
+static s32 XSdPs_Execute_Tuning(XSdPs *InstancePtr)
+{
+	s32 Status;
+	u16 BlkSize;
+	u16 CtrlReg;
+	u8 TuningCount;
+
+	Xil_AssertNonvoid(InstancePtr != NULL);
+	Xil_AssertNonvoid(InstancePtr->IsReady == XIL_COMPONENT_IS_READY);
+
+	BlkSize = XSDPS_TUNING_CMD_BLKSIZE;
+	if(InstancePtr->BusWidth == XSDPS_8_BIT_WIDTH)
+	{
+		BlkSize = BlkSize*2U;
+	}
+	BlkSize &= XSDPS_BLK_SIZE_MASK;
+	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress, XSDPS_BLK_SIZE_OFFSET,
+			BlkSize);
+
+	TransferMode = 	XSDPS_TM_DAT_DIR_SEL_MASK;
+
+	CtrlReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+				XSDPS_HOST_CTRL2_OFFSET);
+	CtrlReg |= XSDPS_HC2_EXEC_TNG_MASK;
+	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+				XSDPS_HOST_CTRL2_OFFSET, CtrlReg);
+
+	/*
+	 * workaround which can work for 1.0/2.0 silicon for auto tuning.
+	 * This can be revisited for 3.0 silicon if necessary.
+	 */
+	/* Wait for ~60 clock cycles to reset the tap values */
+	(void)usleep(1U);
+
+#ifndef versal
+#if defined (ARMR5) || defined (__aarch64__) || defined (ARMA53_32) || defined (__MICROBLAZE__)
+	/* Issue DLL Reset to load new SDHC tuned tap values */
+	XSdPs_DllReset(InstancePtr);
+#endif
+#endif
+
+	for (TuningCount = 0U; TuningCount < MAX_TUNING_COUNT; TuningCount++) {
+
+		if (InstancePtr->CardType == XSDPS_CARD_SD) {
+			Status = XSdPs_CmdTransfer(InstancePtr, CMD19, 0U, 1U);
+		} else {
+			Status = XSdPs_CmdTransfer(InstancePtr, CMD21, 0U, 1U);
+		}
+
+		if (Status != XST_SUCCESS) {
+			Status = XST_FAILURE;
+			goto RETURN_PATH;
+		}
+
+		if ((XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+				XSDPS_HOST_CTRL2_OFFSET) & XSDPS_HC2_EXEC_TNG_MASK) == 0U) {
+			break;
+		}
+
+#ifndef versal
+		if (TuningCount == 31U) {
+#if defined (ARMR5) || defined (__aarch64__) || defined (ARMA53_32) || defined (__MICROBLAZE__)
+			/* Issue DLL Reset to load new SDHC tuned tap values */
+			XSdPs_DllReset(InstancePtr);
+#endif
+		}
+#endif
+	}
+
+	if ((XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_HOST_CTRL2_OFFSET) & XSDPS_HC2_SAMP_CLK_SEL_MASK) == 0U) {
+		Status = XST_FAILURE;
+		goto RETURN_PATH;
+	}
+
+	/* Wait for ~12 clock cycles to synchronize the new tap values */
+	(void)usleep(1U);
+
+#ifndef versal
+#if defined (ARMR5) || defined (__aarch64__) || defined (ARMA53_32) || defined (__MICROBLAZE__)
+	/* Issue DLL Reset to load new SDHC tuned tap values */
+	XSdPs_DllReset(InstancePtr);
+#endif
+#endif
+
+	Status = XST_SUCCESS;
+
+	RETURN_PATH: return Status;
+
+}
+
+#if defined (ARMR5) || defined (__aarch64__) || defined (ARMA53_32) || defined (__MICROBLAZE__)
+
+#ifndef versal
+#if EL1_NONSECURE && defined (__aarch64__)
+static inline void XSdps_Smc(u32 RegOffset, u32 Mask, u32 Val)
+{
+	(void)Xil_Smc(MMIO_WRITE_SMC_FID, (u64)(XPS_SYS_CTRL_BASEADDR +
+			RegOffset) | ((u64)Mask << 32),
+			(u64)Val, 0, 0, 0, 0, 0);
+}
+#endif
+
+/*****************************************************************************/
+/**
+*
+* API to Set or Reset the DLL
+*
+*
+* @param	InstancePtr is a pointer to the XSdPs instance.
+* @param	EnRst is a flag indicating whether to Assert or De-assert Reset.
+*
+* @return	None
+*
+* @note		None.
+*
+******************************************************************************/
+static void XSdPs_DllRstCtrl(XSdPs *InstancePtr, u8 EnRst)
+{
+	u32 DeviceId = InstancePtr->Config.DeviceId;
+	u32 DllCtrl;
+
+#ifdef XPAR_PSU_SD_0_DEVICE_ID
+	if (DeviceId == 0U) {
+#if EL1_NONSECURE && defined (__aarch64__)
+		(void)DllCtrl;
+
+		XSdps_Smc(SD_DLL_CTRL, SD0_DLL_RST, (EnRst == 1U) ? SD0_DLL_RST : 0U);
+#else
+		DllCtrl = XSdPs_ReadReg(XPS_SYS_CTRL_BASEADDR, SD_DLL_CTRL);
+		if (EnRst == 1U) {
+			DllCtrl |= SD0_DLL_RST;
+		} else {
+			DllCtrl &= ~SD0_DLL_RST;
+		}
+		XSdPs_WriteReg(XPS_SYS_CTRL_BASEADDR, SD_DLL_CTRL, DllCtrl);
+#endif
+	} else {
+#endif /* XPAR_PSU_SD_0_DEVICE_ID */
+		(void) DeviceId;
+#if EL1_NONSECURE && defined (__aarch64__)
+		(void)DllCtrl;
+
+		XSdps_Smc(SD_DLL_CTRL, SD1_DLL_RST, (EnRst == 1U) ? SD1_DLL_RST : 0U);
+#else
+		DllCtrl = XSdPs_ReadReg(XPS_SYS_CTRL_BASEADDR, SD_DLL_CTRL);
+		if (EnRst == 1U) {
+			DllCtrl |= SD1_DLL_RST;
+		} else {
+			DllCtrl &= ~SD1_DLL_RST;
+		}
+		XSdPs_WriteReg(XPS_SYS_CTRL_BASEADDR, SD_DLL_CTRL, DllCtrl);
+#endif
+#ifdef XPAR_PSU_SD_0_DEVICE_ID
+	}
+#endif
+}
+
+/*****************************************************************************/
+/**
+*
+* API to reset the DLL
+*
+*
+* @param	InstancePtr is a pointer to the XSdPs instance.
+*
+* @return	None
+*
+* @note		None.
+*
+******************************************************************************/
+static void XSdPs_DllReset(XSdPs *InstancePtr)
+{
+	u32 ClockReg;
+
+	/* Disable clock */
+	ClockReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_CLK_CTRL_OFFSET);
+	ClockReg &= ~XSDPS_CC_SD_CLK_EN_MASK;
+	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_CLK_CTRL_OFFSET, (u16)ClockReg);
+
+	/* Issue DLL Reset to load zero tap values */
+	XSdPs_DllRstCtrl(InstancePtr, 1U);
+
+	/* Wait for 2 micro seconds */
+	(void)usleep(2U);
+
+	XSdPs_DllRstCtrl(InstancePtr, 0U);
+
+	/* Wait for internal clock to stabilize */
+	ClockReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+				XSDPS_CLK_CTRL_OFFSET);
+	while((ClockReg & XSDPS_CC_INT_CLK_STABLE_MASK) == 0U) {
+		ClockReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+					XSDPS_CLK_CTRL_OFFSET);
+	}
+
+	/* Enable SD clock */
+	ClockReg = XSdPs_ReadReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_CLK_CTRL_OFFSET);
+	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress,
+			XSDPS_CLK_CTRL_OFFSET,
+			ClockReg | XSDPS_CC_SD_CLK_EN_MASK);
+}
+#endif
+
+/*****************************************************************************/
+/**
+*
+* Function to configure the Tap Delays.
+*
+*
+* @param	InstancePtr is a pointer to the XSdPs instance.
+*
+* @return	None
+*
+* @note		None.
+*
+******************************************************************************/
+static void XSdPs_ConfigTapDelay(XSdPs *InstancePtr)
+{
+	u32 DeviceId = InstancePtr->Config.DeviceId ;
+	u32 TapDelay = 0U;
+	u32 ITapDelay = InstancePtr->ITapDelay;
+	u32 OTapDelay = InstancePtr->OTapDelay;
+
+#ifdef versal
+	(void) DeviceId;
+	if (ITapDelay) {
+		TapDelay = SD_ITAPCHGWIN;
+		XSdPs_WriteReg(InstancePtr->Config.BaseAddress, SD_ITAPDLY, TapDelay);
+		/* Program the ITAPDLY */
+		TapDelay |= SD_ITAPDLYENA;
+		XSdPs_WriteReg(InstancePtr->Config.BaseAddress, SD_ITAPDLY, TapDelay);
+		TapDelay |= ITapDelay;
+		XSdPs_WriteReg(InstancePtr->Config.BaseAddress, SD_ITAPDLY, TapDelay);
+		TapDelay &= ~SD_ITAPCHGWIN;
+		XSdPs_WriteReg(InstancePtr->Config.BaseAddress, SD_ITAPDLY, TapDelay);
+	}
+	if (OTapDelay) {
+		/* Program the OTAPDLY */
+		TapDelay = SD_OTAPDLYENA;
+		XSdPs_WriteReg(InstancePtr->Config.BaseAddress, SD_OTAPDLY, TapDelay);
+		TapDelay |= OTapDelay;
+		XSdPs_WriteReg(InstancePtr->Config.BaseAddress, SD_OTAPDLY, TapDelay);
+	}
+#else
+#ifdef XPAR_PSU_SD_0_DEVICE_ID
+	if (DeviceId == 0U) {
+#if EL1_NONSECURE && defined (__aarch64__)
+		(void)TapDelay;
+		if (ITapDelay) {
+			XSdps_Smc(SD_ITAPDLY, SD0_ITAPCHGWIN, SD0_ITAPCHGWIN);
+			XSdps_Smc(SD_ITAPDLY, SD0_ITAPDLYENA, SD0_ITAPDLYENA);
+			XSdps_Smc(SD_ITAPDLY, SD0_ITAPDLY_SEL_MASK, ITapDelay);
+			XSdps_Smc(SD_ITAPDLY, SD0_ITAPCHGWIN, 0U);
+		}
+		if (OTapDelay) {
+			XSdps_Smc(SD_OTAPDLY, SD0_OTAPDLY_SEL_MASK, OTapDelay);
+		}
+#else
+		if (ITapDelay) {
+			TapDelay = XSdPs_ReadReg(XPS_SYS_CTRL_BASEADDR, SD_ITAPDLY);
+			TapDelay |= SD0_ITAPCHGWIN;
+			XSdPs_WriteReg(XPS_SYS_CTRL_BASEADDR, SD_ITAPDLY, TapDelay);
+			/* Program the ITAPDLY */
+			TapDelay |= SD0_ITAPDLYENA;
+			XSdPs_WriteReg(XPS_SYS_CTRL_BASEADDR, SD_ITAPDLY, TapDelay);
+			TapDelay |= ITapDelay;
+			XSdPs_WriteReg(XPS_SYS_CTRL_BASEADDR, SD_ITAPDLY, TapDelay);
+			TapDelay &= ~SD0_ITAPCHGWIN;
+			XSdPs_WriteReg(XPS_SYS_CTRL_BASEADDR, SD_ITAPDLY, TapDelay);
+		}
+		if (OTapDelay) {
+			/* Program the OTAPDLY */
+			TapDelay = XSdPs_ReadReg(XPS_SYS_CTRL_BASEADDR, SD_OTAPDLY);
+			TapDelay &= ~SD0_OTAPDLY_SEL_MASK;
+			TapDelay |= OTapDelay;
+			XSdPs_WriteReg(XPS_SYS_CTRL_BASEADDR, SD_OTAPDLY, TapDelay);
+		}
+#endif
+	} else {
+#endif
+		(void) DeviceId;
+		ITapDelay = ITapDelay << 16U;
+		OTapDelay = OTapDelay << 16U;
+#if EL1_NONSECURE && defined (__aarch64__)
+		(void)TapDelay;
+		if (ITapDelay) {
+			XSdps_Smc(SD_ITAPDLY, SD1_ITAPCHGWIN, SD1_ITAPCHGWIN);
+			XSdps_Smc(SD_ITAPDLY, SD1_ITAPDLYENA, SD1_ITAPDLYENA);
+			XSdps_Smc(SD_ITAPDLY, SD1_ITAPDLY_SEL_MASK, ITapDelay);
+			XSdps_Smc(SD_ITAPDLY, SD1_ITAPCHGWIN, 0U);
+		}
+		if (OTapDelay) {
+			XSdps_Smc(SD_OTAPDLY, SD1_OTAPDLY_SEL_MASK, OTapDelay);
+		}
+#else
+		if (ITapDelay) {
+			TapDelay = XSdPs_ReadReg(XPS_SYS_CTRL_BASEADDR, SD_ITAPDLY);
+			TapDelay |= SD1_ITAPCHGWIN;
+			XSdPs_WriteReg(XPS_SYS_CTRL_BASEADDR, SD_ITAPDLY, TapDelay);
+			/* Program the ITAPDLY */
+			TapDelay |= SD1_ITAPDLYENA;
+			XSdPs_WriteReg(XPS_SYS_CTRL_BASEADDR, SD_ITAPDLY, TapDelay);
+			TapDelay |= ITapDelay;
+			XSdPs_WriteReg(XPS_SYS_CTRL_BASEADDR, SD_ITAPDLY, TapDelay);
+			TapDelay &= ~SD1_ITAPCHGWIN;
+			XSdPs_WriteReg(XPS_SYS_CTRL_BASEADDR, SD_ITAPDLY, TapDelay);
+		}
+		if (OTapDelay) {
+			/* Program the OTAPDLY */
+			TapDelay = XSdPs_ReadReg(XPS_SYS_CTRL_BASEADDR, SD_OTAPDLY);
+			TapDelay &= ~SD1_OTAPDLY_SEL_MASK;
+			TapDelay |= OTapDelay;
+			XSdPs_WriteReg(XPS_SYS_CTRL_BASEADDR, SD_OTAPDLY, TapDelay);
+		}
+#endif
+#ifdef XPAR_PSU_SD_0_DEVICE_ID
+	}
+#endif
+#endif /* versal */
+}
+
+/*****************************************************************************/
+/**
+*
+* API to set Tap Delay w.r.t speed modes
+*
+*
+* @param	InstancePtr is a pointer to the XSdPs instance.
+*
+* @return	None
+*
+* @note		None.
+*
+******************************************************************************/
+void XSdPs_SetTapDelay(XSdPs *InstancePtr)
+{
+#ifndef versal
+	/* Issue DLL Reset */
+	XSdPs_DllRstCtrl(InstancePtr, 1U);
+#endif
+
+	/* Configure the Tap Delay Registers */
+	XSdPs_ConfigTapDelay(InstancePtr);
+
+#ifndef versal
+	/* Release the DLL out of reset */
+	XSdPs_DllRstCtrl(InstancePtr, 0U);
+#endif
+}
+#endif
+/** @} */

--- a/portable/Zynq.2019.3/xsdps_sinit.c
+++ b/portable/Zynq.2019.3/xsdps_sinit.c
@@ -1,0 +1,94 @@
+/******************************************************************************
+*
+* Copyright (C) 2013 - 2019 Xilinx, Inc.  All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*
+*
+*
+******************************************************************************/
+/*****************************************************************************/
+/**
+*
+* @file xsdps_sinit.c
+* @addtogroup sdps_v3_8
+* @{
+*
+* The implementation of the XSdPs component's static initialization
+* functionality.
+*
+* <pre>
+* MODIFICATION HISTORY:
+*
+* Ver   Who    Date     Changes
+* ----- ---    -------- -----------------------------------------------
+* 1.00a hk/sg  10/17/13 Initial release
+*       kvn    07/15/15 Modified the code according to MISRAC-2012.
+* 3.7   aru    03/12/19 Modified the code according to MISRAC-2012.
+*
+* </pre>
+*
+******************************************************************************/
+
+/***************************** Include Files *********************************/
+#include "xstatus.h"
+#include "xsdps.h"
+#include "xparameters.h"
+/************************** Constant Definitions *****************************/
+
+/**************************** Type Definitions *******************************/
+
+/***************** Macros (Inline Functions) Definitions *********************/
+
+/************************** Function Prototypes ******************************/
+
+/************************** Variable Definitions *****************************/
+extern XSdPs_Config XSdPs_ConfigTable[XPAR_XSDPS_NUM_INSTANCES];
+
+/*****************************************************************************/
+/**
+*
+* Looks up the device configuration based on the unique device ID. A table
+* contains the configuration info for each device in the system.
+*
+* @param	DeviceId contains the ID of the device to look up the
+*		configuration for.
+*
+* @return
+*
+* A pointer to the configuration found or NULL if the specified device ID was
+* not found. See xsdps.h for the definition of XSdPs_Config.
+*
+* @note		None.
+*
+******************************************************************************/
+XSdPs_Config *XSdPs_LookupConfig(u16 DeviceId)
+{
+	XSdPs_Config *CfgPtr = NULL;
+	u32 Index;
+
+	for (Index = 0U; Index < (u32)XPAR_XSDPS_NUM_INSTANCES; Index++) {
+		if (XSdPs_ConfigTable[Index].DeviceId == DeviceId) {
+			CfgPtr = &XSdPs_ConfigTable[Index];
+			break;
+		}
+	}
+	return (XSdPs_Config *)CfgPtr;
+}
+/** @} */

--- a/portable/avr32_uc3/ff_locking.c
+++ b/portable/avr32_uc3/ff_locking.c
@@ -168,6 +168,15 @@ void FF_Sleep( uint32_t ulTime_ms )
 }
 /*-----------------------------------------------------------*/
 
+void FF_DeleteEvents( FF_IOManager_t *pxIOManager )
+{
+	if( pxIOManager->xEventGroup != NULL )
+	{
+		vEventGroupDelete( pxIOManager->xEventGroup );
+	}
+}
+/*-----------------------------------------------------------*/
+
 BaseType_t FF_CreateEvents( FF_IOManager_t *pxIOManager )
 {
 BaseType_t xResult;


### PR DESCRIPTION
The module [FF_Locking.c](https://github.com/FreeRTOS/Lab-Project-FreeRTOS-FAT/blob/master/ff_locking.c) makes sure that only a single task can enter into a "critical section". It uses an event group for this purpose, with either of these bits:
~~~c
FF_DIR_LOCK_EVENT_BITS
FF_FAT_LOCK_EVENT_BITS
FF_BUF_LOCK_EVENT_BITS
~~~
[Carl Kugler](https://forums.freertos.org/t/freertos-fat-ff-ftell-oddities/10976/13) noticed that the code was not entirely correct: in stead of calling `xEventGroupWaitBits()` followed by `xEventGroupClearBits()`, it is enough to call:
~~~c
    xBits = xEventGroupWaitBits( pxIOManager->xEventGroup,
        FF_DIR_LOCK_EVENT_BITS, /* uxBitsToWaitFor */
        pdTRUE,                 /* xClearOnExit */
        pdFALSE,                /* xWaitForAllBits n.a. */
        pdMS_TO_TICKS( 10000UL ) );
~~~
with `xClearOnExit` set to `pdTRUE`. This happens in 3 locations in the file.

The physical access to the disk is protected with a mutex.

The `FF_BUF_LOCK_EVENT_BITS` is not a real lock: it only serves to let a task sleep while it is waiting for a buffer.

Also this PR will replace the magic number `10000UL` with a macro.