### PR TITLE
Changes to ff_locking use of event groups, version 2.

### DIFF
--- a/ff_locking.c
+++ b/ff_locking.c
@@ -57,6 +57,13 @@ The masks below are used when calling Group Event functions. */
 each time when a sector buffer is released. */
 #define FF_BUF_LOCK_EVENT_BITS    ( ( const EventBits_t ) FF_BUF_LOCK )
 
+#define FF_TIME_TO_WAIT_FOR_EVENT_TICKS
+	/* The maximum time to wait for a event group bit to come high,
+	 * which gives access to a "critical section": either directories,
+	 * or the FAT. */
+	#define FF_TIME_TO_WAIT_FOR_EVENT_TICKS  pdMS_TO_TICKS( 10000UL )
+#endif
+
 /*-----------------------------------------------------------*/
 
 BaseType_t FF_TrySemaphore( void *pxSemaphore, uint32_t ulTime_ms )
@@ -157,7 +164,7 @@ void FF_LockDirectory( FF_IOManager_t *pxIOManager )
 			FF_DIR_LOCK_EVENT_BITS, /* uxBitsToWaitFor */
 			pdTRUE,                 /* xClearOnExit */
 			pdFALSE,                /* xWaitForAllBits n.a. */
-			pdMS_TO_TICKS( 10000UL ) );
+			FF_TIME_TO_WAIT_FOR_EVENT_TICKS );
 
 		if( ( xBits & FF_DIR_LOCK_EVENT_BITS ) != 0 )
 		{
@@ -250,7 +257,7 @@ EventBits_t xBits;
 			FF_FAT_LOCK_EVENT_BITS, /* uxBitsToWaitFor */
 			pdTRUE,                 /* xClearOnExit */
 			pdFALSE,                /* xWaitForAllBits n.a. */
-			pdMS_TO_TICKS( 10000UL ) );
+			FF_TIME_TO_WAIT_FOR_EVENT_TICKS );
 
 		if( ( xBits & FF_FAT_LOCK_EVENT_BITS ) != 0 )
 		{

--- a/ff_locking.c
+++ b/ff_locking.c
@@ -151,16 +151,13 @@ void FF_LockDirectory( FF_IOManager_t *pxIOManager )
 	for( ;; )
 	{
 		/* Called when a task want to make changes to a directory.
-		First it waits for the desired bit to come high. */
-		xEventGroupWaitBits( pxIOManager->xEventGroup,
+		It waits for the desired bit to come high, and clears the
+		bit so that other tasks can not take it. */
+		xBits = xEventGroupWaitBits( pxIOManager->xEventGroup,
 			FF_DIR_LOCK_EVENT_BITS, /* uxBitsToWaitFor */
-			( EventBits_t )0,       /* xClearOnExit */
+			pdTRUE,                 /* xClearOnExit */
 			pdFALSE,                /* xWaitForAllBits n.a. */
 			pdMS_TO_TICKS( 10000UL ) );
-
-		/* The next operation will only succeed for 1 task at a time,
-		because it is an atomary test & set operation: */
-		xBits = xEventGroupClearBits( pxIOManager->xEventGroup, FF_DIR_LOCK_EVENT_BITS );
 
 		if( ( xBits & FF_DIR_LOCK_EVENT_BITS ) != 0 )
 		{
@@ -247,16 +244,13 @@ EventBits_t xBits;
 	for( ;; )
 	{
 		/* Called when a task want to make changes to the FAT area.
-		First it waits for the desired bit to come high. */
-		xEventGroupWaitBits( pxIOManager->xEventGroup,
+		It waits for the desired bit to come high, and clears the
+		bit so that other tasks can not take it. */
+		xBits = xEventGroupWaitBits( pxIOManager->xEventGroup,
 			FF_FAT_LOCK_EVENT_BITS, /* uxBitsToWaitFor */
-			( EventBits_t )0,       /* xClearOnExit */
+			pdTRUE,                 /* xClearOnExit */
 			pdFALSE,                /* xWaitForAllBits n.a. */
 			pdMS_TO_TICKS( 10000UL ) );
-
-		/* The next operation will only succeed for 1 task at a time,
-		because it is an atomary test & set operation: */
-		xBits = xEventGroupClearBits( pxIOManager->xEventGroup, FF_FAT_LOCK_EVENT_BITS );
 
 		if( ( xBits & FF_FAT_LOCK_EVENT_BITS ) != 0 )
 		{
@@ -293,10 +287,11 @@ BaseType_t xReturn;
 		return pdTRUE;
 	}
 	/* This function is called when a task is waiting for a sector buffer
-	to become available. */
+	to become available.  Each time when a sector buffer becomes available,
+	the bit will be set ( see FF_BufferProceed() here below ). */
 	xBits = xEventGroupWaitBits( pxIOManager->xEventGroup,
 		FF_BUF_LOCK_EVENT_BITS, /* uxBitsToWaitFor */
-		FF_BUF_LOCK_EVENT_BITS, /* xClearOnExit */
+		pdTRUE,                 /* xClearOnExit */
 		pdFALSE,                /* xWaitForAllBits n.a. */
 		pdMS_TO_TICKS( xWaitMS ) );
 	if( ( xBits & FF_BUF_LOCK_EVENT_BITS ) != 0 )
@@ -319,7 +314,7 @@ void FF_BufferProceed( FF_IOManager_t *pxIOManager )
 		/* Scheduler not yet active. */
 		return;
 	}
-	/* Wake-up all tasks that are waiting for a sector buffer to become available. */
+	/* Wake-up a task that is waiting for a sector buffer to become available. */
 	xEventGroupSetBits( pxIOManager->xEventGroup, FF_BUF_LOCK_EVENT_BITS );
 }
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
The module [FF_Locking.c](https://github.com/FreeRTOS/Lab-Project-FreeRTOS-FAT/blob/master/ff_locking.c) makes sure that only a single task can enter into a "critical section".  It uses an event group for this purpose, with either of these bits:
~~~c
FF_DIR_LOCK_EVENT_BITS  // To make changes to a directory.
FF_FAT_LOCK_EVENT_BITS  // To make changes to the FAT.
FF_BUF_LOCK_EVENT_BITS  // To wait for an available cache buffer.
~~~
[Carl Kugler](https://forums.freertos.org/t/freertos-fat-ff-ftell-oddities/10976/13) noticed that the code could be optimised: in stead of calling `xEventGroupWaitBits()` followed by `xEventGroupClearBits()`, it is enough to call:
~~~c
    xBits = xEventGroupWaitBits( pxIOManager->xEventGroup,
        FF_DIR_LOCK_EVENT_BITS, /* uxBitsToWaitFor */
        pdTRUE,                 /* xClearOnExit */
        pdFALSE,                /* xWaitForAllBits n.a. */
        FF_TIME_TO_WAIT_FOR_EVENT_TICKS );
~~~
with `xClearOnExit` set to `pdTRUE`.  This happens in 3 locations in the file.

The physical access to the disk is protected with a mutex, and has nothing to do with these event groups.

The `FF_BUF_LOCK_EVENT_BITS` is not a real lock: it only serves to let a task sleep while it is waiting for a free buffer.

Also this PR will replace the magic number `10000UL` with a macro.

Note that also before this PR, the code did work correctly: only a single task could enter a "critical section".