### PR TITLE
Fix warning in ff_dir.c

### DIFF
--- a/ff_dir.c
+++ b/ff_dir.c
@@ -2518,7 +2518,7 @@ uint32_t ulCluster;
 				}
 				#elif ( ffconfigUNICODE_UTF8_SUPPORT != 0 )
 				{
-					NamePtr = ( int8_t * ) ( usUtf16Name + 13 * ( xNumLFNs - 1 ) );
+					NamePtr = ( char * ) ( usUtf16Name + 13 * ( xNumLFNs - 1 ) );
 				}
 				#else
 				{


### PR DESCRIPTION
This commit fixes warning:
warning: pointer targets in assignment from 'int8_t *' {aka 'signed char *'} to 'char *' differ in signedness [-Wpointer-sign]