### PR TITLE
Handle driver-busy error code correctly.

### DIFF
--- a/ff_ioman.c
+++ b/ff_ioman.c
@@ -604,7 +604,9 @@ int32_t FF_BlockRead( FF_IOManager_t * pxIOManager,
                 FF_ReleaseSemaphore( pxIOManager->pvSemaphore );
             }
 
-            if( FF_GETERROR( slRetVal ) != FF_ERR_DRIVER_BUSY )
+            /* Do not use 'FF_GETERROR()' here because FF_ERR_DRIVER_BUSY
+             * is a full 32-bit error code. */
+            if( slRetVal != FF_ERR_DRIVER_BUSY )
             {
                 break;
             }
@@ -653,7 +655,9 @@ int32_t FF_BlockWrite( FF_IOManager_t * pxIOManager,
                 FF_ReleaseSemaphore( pxIOManager->pvSemaphore );
             }
 
-            if( FF_GETERROR( slRetVal ) != FF_ERR_DRIVER_BUSY )
+            /* Do not use 'FF_GETERROR()' here because FF_ERR_DRIVER_BUSY
+             * is a full 32-bit error code. */
+            if( slRetVal != FF_ERR_DRIVER_BUSY )
             {
                 break;
             }


### PR DESCRIPTION
In two occasions in [ff_ioman.c](https://github.com/FreeRTOS/Lab-Project-FreeRTOS-FAT/blob/master/ff_ioman.c#L607), the return code was tested incorrectly:

~~~c
+    /* Do not use 'FF_GETERROR()' here because FF_ERR_DRIVER_BUSY
+     * is a full 32-bit error code. */
-    if( FF_GETERROR( slRetVal ) != FF_ERR_DRIVER_BUSY )
+    if( slRetVal != FF_ERR_DRIVER_BUSY )
~~~

`FF_ERR_DRIVER_BUSY` is an error code that a driver can return in case it is busy and wants to be called again later. With the earlier code, the access function ( read or write ) would never be called a second time.

FreeRTOS+FAT uses a 32-bit error codes, which include the module, the function, and in the lower 16 bits: the actual error code.

Thanks to [Simon Benoit](https://github.com/Eriobis) who created [issue 7](https://github.com/FreeRTOS/FreeRTOS-Labs/issues/7) about this.
