### PR TITLE
FAT: Changes for 64-bit platforms and solved compiler warnings

### DIFF
--- a/include/FreeRTOSFATConfigDefaults.h
+++ b/include/FreeRTOSFATConfigDefaults.h
@@ -460,4 +460,38 @@
     }
 #endif
 
+#ifndef ffconfigUSE_NOTIFY
+
+/* When defined, the driver will call a user hook "callFileEvents()"
+ * for certain events: creation, change, and deletion of a file or
+ * directory.
+ * For instance: it can be useful to get an event as soon as a set-up
+ * file has changed, or when a lock-file has been placed or removed.
+ */
+    #define ffconfigUSE_NOTIFY    0
+#endif
+
+#ifndef ffconfigDEV_SUPPORT
+
+/* A rarely used feature of FreeRTOS+FAT which lets files behave
+ * as 'devices'. */
+    #define ffconfigDEV_SUPPORT    0
+#endif
+
+#ifndef USE_SOFT_WDT
+
+/* When true. a user-provided function `clearWDT()` will be called
+ * during a long action. */
+    #define USE_SOFT_WDT    0
+#endif
+
+#ifndef ffconfigNOT_USED_FOR_NOW
+
+/* This macro was once used for debugging.
+ * When defined as 1, the function 'FF_Utf16ctoUtf32c()'
+ * will be compiled */
+    #define ffconfigNOT_USED_FOR_NOW    0
+#endif
+
+
 #endif /* ifndef FF_DEFAULTCONFIG_H */

--- a/include/ff_stdio.h
+++ b/include/ff_stdio.h
@@ -128,7 +128,14 @@
 /* The errno is stored in a thread local buffer. */
     static portINLINE void stdioSET_ERRNO( int iErrno )
     {
-        vTaskSetThreadLocalStoragePointer( NULL, ffconfigCWD_THREAD_LOCAL_INDEX, ( void * ) ( iErrno ) );
+        /* Local storage pointers can only store pointers. This function
+         * wants to store a signed errno value, which needs a cast. */
+        /* Cast from an integer to a signed value of a pointer size. */
+        intptr_t xErrno = ( intptr_t ) iErrno;
+        /* Cast from a numeric value to a pointer. */
+        void * pvValue = ( void * ) ( xErrno );
+
+        vTaskSetThreadLocalStoragePointer( NULL, ffconfigCWD_THREAD_LOCAL_INDEX, pvValue );
     }
 
     static portINLINE int stdioGET_ERRNO( void )
@@ -136,7 +143,12 @@
         void * pvResult;
 
         pvResult = pvTaskGetThreadLocalStoragePointer( ( TaskHandle_t ) NULL, ffconfigCWD_THREAD_LOCAL_INDEX );
-        return ( int ) pvResult;
+        /* Cast from a pointer to a number of the same size. */
+        intptr_t xErrno = ( intptr_t ) pvResult;
+        /* Cast it to an integer. */
+        int iValue = ( int ) ( xErrno );
+
+        return iValue;
     }
 
     #if ( ( configNUM_THREAD_LOCAL_STORAGE_POINTERS - ffconfigCWD_THREAD_LOCAL_INDEX ) < 3 )
@@ -148,7 +160,14 @@
  */
     static portINLINE void stdioSET_FF_ERROR( FF_Error_t iFF_ERROR )
     {
-        vTaskSetThreadLocalStoragePointer( NULL, stdioFF_ERROR_THREAD_LOCAL_OFFSET, ( void * ) ( iFF_ERROR ) );
+        /* Cast it to an unsigned long. */
+        uint32_t ulError = ( uint32_t ) iFF_ERROR;
+        /* Cast it to a number with the size of a pointer. */
+        uintptr_t uxErrno = ( uintptr_t ) ulError;
+        /* Cast it to a void pointer. */
+        void * pvValue = ( void * ) ( uxErrno );
+
+        vTaskSetThreadLocalStoragePointer( NULL, stdioFF_ERROR_THREAD_LOCAL_OFFSET, pvValue );
     }
 
 /*
@@ -160,7 +179,12 @@
         void * pvResult;
 
         pvResult = pvTaskGetThreadLocalStoragePointer( NULL, stdioFF_ERROR_THREAD_LOCAL_OFFSET );
-        return ( FF_Error_t ) pvResult;
+        /* Cast it to an integer with the same size as a pointer. */
+        intptr_t uxErrno = ( intptr_t ) pvResult;
+        /* Cast it to a int32_t. */
+        FF_Error_t xError = ( FF_Error_t ) uxErrno;
+
+        return xError;
     }
 
 /*-----------------------------------------------------------


### PR DESCRIPTION
This PR addresses some compiler warnings:

1. One reported on the FreeRTOS forum: ["FreeRTOS+FAT build warning/error messages"](https://forums.freertos.org/t/freertos-fat-build-warning-error-messages/13070)

2. The other reported in Github as issue #20: ["Compiler Warnings on 64-Bit Build"](https://github.com/FreeRTOS/Lab-Project-FreeRTOS-FAT/issues/20)

[Jonathan](https://forums.freertos.org/u/gebjon) is right : the project should compile equally well when using `-Wundef`.

The compiler errors had to do with undefined macros. Throughout the library it is assumed that undefined macros are treated as zero.

In ff_stdio.h, there were some casts from an integer to a void pointer and vv.  I have split up these casts into smaller steps, like e.g. here:
~~~c
static portINLINE void stdioSET_ERRNO( int iErrno )
{
    /* Local storage pointers can only store pointers. This function
     * wants to store a signed errno value, which needs a cast. */
    /* Cast from an integer to a signed value of a pointer size. */
    intptr_t xErrno = ( intptr_t ) iErrno;
    /* Cast from a numeric value to a pointer. */
    void * pvValue = ( void * ) ( xErrno );

    vTaskSetThreadLocalStoragePointer( NULL, ffconfigCWD_THREAD_LOCAL_INDEX, pvValue );
}
~~~
