### PR TITLE
When appending to a file, update ulCurrentCluster only once

### DIFF
--- a/ff_file.c
+++ b/ff_file.c
@@ -62,7 +62,7 @@ static uint32_t FF_SetCluster( FF_FILE * pxFile,
 static uint32_t FF_FileLBA( FF_FILE * pxFile );
 
 static FF_Error_t FF_ExtendFile( FF_FILE * pxFile,
-								 uint32_t ulSize );
+                                 uint32_t ulSize );
 
 /*-----------------------------------------------------------*/
 
@@ -1444,27 +1444,30 @@ static FF_Error_t FF_ExtendFile( FF_FILE * pxFile,
             }
         #endif /* ffconfigFILE_EXTEND_FLUSHES_BUFFERS */
 
-		if( pxFile->ulFilePointer == pxFile->ulFileSize )
-		{
-			/* Writing at the end of a file, while new clusters have just been added.
-			 * Make sure that the fields 'ulCurrentCluster' and 'ulAddrCurrentCluster' are
-			 * set correctly.
-			 */
-			FF_Error_t xTempError = FF_ERR_NONE;
-			uint32_t ulNewCluster = FF_getClusterChainNumber( pxIOManager, pxFile->ulFilePointer, 1 );
+        if( pxFile->ulFilePointer == pxFile->ulFileSize )
+        {
+            /* Writing at the end of a file, while new clusters have just been added.
+             * Make sure that the fields 'ulCurrentCluster' and 'ulAddrCurrentCluster' are
+             * set correctly.
+             */
+            if( ( pxFile->ulValidFlags & FF_VALID_FLAG_EXTENDED ) == 0U )
+            {
+                pxFile->ulValidFlags |= FF_VALID_FLAG_EXTENDED;
+                FF_Error_t xTempError = FF_ERR_NONE;
+                uint32_t ulNewCluster = FF_getClusterChainNumber( pxIOManager, pxFile->ulFilePointer, 1 );
+                FF_LockFAT( pxIOManager );
+                {
+                    pxFile->ulAddrCurrentCluster = FF_TraverseFAT( pxIOManager, pxFile->ulObjectCluster, ulNewCluster, &( xTempError ) );
+                    pxFile->ulCurrentCluster = ulNewCluster;
+                }
+                FF_UnlockFAT( pxIOManager );
 
-			FF_LockFAT( pxIOManager );
-			{
-				pxFile->ulAddrCurrentCluster = FF_TraverseFAT( pxIOManager, pxFile->ulObjectCluster, ulNewCluster, &( xTempError ) );
-				pxFile->ulCurrentCluster = ulNewCluster;
-			}
-			FF_UnlockFAT( pxIOManager );
-
-			if( FF_isERR( xError ) == pdFALSE )
-			{
-				xError = xTempError;
-			}
-		}
+                if( FF_isERR( xError ) == pdFALSE )
+                {
+                    xError = xTempError;
+                }
+            }
+        }
     } /* if( ulTotalClustersNeeded > pxFile->ulChainLength ) */
 
     return xError;
@@ -1482,7 +1485,7 @@ static FF_Error_t FF_WriteClusters( FF_FILE * pxFile,
 
     while( ulCount != 0 )
     {
-		if( ulCount > 1U )
+        if( ulCount > 1U )
         {
             ulSequentialClusters =
                 FF_GetSequentialClusters( pxFile->pxIOManager, pxFile->ulAddrCurrentCluster, ulCount - 1, &xError );
@@ -1492,10 +1495,10 @@ static FF_Error_t FF_WriteClusters( FF_FILE * pxFile,
                 break;
             }
         }
-		else
-		{
-			/* Handling the last cluster which is a single one. */
-		}
+        else
+        {
+            /* Handling the last cluster which is a single one. */
+        }
 
         ulSectors = ( ulSequentialClusters + 1 ) * pxFile->pxIOManager->xPartition.ulSectorsPerCluster;
         ulItemLBA = FF_Cluster2LBA( pxFile->pxIOManager, pxFile->ulAddrCurrentCluster );

--- a/include/ff_file.h
+++ b/include/ff_file.h
@@ -79,9 +79,9 @@ typedef struct _FF_FILE
     struct _FF_FILE * pxNext; /* Pointer to the next file object in the linked list. */
 } FF_FILE;
 
-#define FF_VALID_FLAG_INVALID     0x00000001
-#define FF_VALID_FLAG_DELETED     0x00000002
-#define FF_VALID_FLAG_EXTENDED    0x00000004
+#define FF_VALID_FLAG_INVALID     0x00000001U
+#define FF_VALID_FLAG_DELETED     0x00000002U
+#define FF_VALID_FLAG_EXTENDED    0x00000004U
 
 /*---------- PROTOTYPES */
 /* PUBLIC (Interfaces): */

--- a/include/ff_file.h
+++ b/include/ff_file.h
@@ -79,8 +79,9 @@ typedef struct _FF_FILE
     struct _FF_FILE * pxNext; /* Pointer to the next file object in the linked list. */
 } FF_FILE;
 
-#define FF_VALID_FLAG_INVALID    0x00000001
-#define FF_VALID_FLAG_DELETED    0x00000002
+#define FF_VALID_FLAG_INVALID     0x00000001
+#define FF_VALID_FLAG_DELETED     0x00000002
+#define FF_VALID_FLAG_EXTENDED    0x00000004
 
 /*---------- PROTOTYPES */
 /* PUBLIC (Interfaces): */


### PR DESCRIPTION
A while ago, @MateuszKlatecki raised issue #15 which I diagnosed as follows:

"When a file has a length which is exactly a multiple of the cluster size, there will be no (reserved) space to append data. In that case, (a) new cluster(s) must first be allocated.
This is done in the function `FF_ExtendFile()`.
It assumes that `ulCurrentCluster` and `ulAddrCurrentCluster` will point to the newly allocated cluster. Therefore the data were written to the before-last cluster."

This was corrected this in the function `FF_ExtendFile()` in PR #17.

This change worked well. However, I found that the operation becomes relatively expensive when a huge file is written to a fast medium, like a RAM disk. The writing speed would drop by more than a 2/3.

For PR #17, I tested by copying many files using FTP to a memory card. I didn't really notice that lower speeds because the medium was relatively slow.

Fortunately, calculating the fields `ulCurrentCluster` and `ulAddrCurrentCluster` only needs to be done once. After that, the library will make sure that [space for at least 1 byte](https://github.com/FreeRTOS/Lab-Project-FreeRTOS-FAT/blob/bbf2c67e590eb00a9ecdd08220183fb66b5534dd/ff_file.c#L2266) is reserved.

Symbolically:
~~~c
+if( ( pxFile->ulValidFlags & FF_VALID_FLAG_EXTENDED ) == 0U )
+{
     /* Get here only once. */
     pxFile->ulValidFlags |= FF_VALID_FLAG_EXTENDED;
     /* Calculate the two fields ulCurrentCluster and ulAddrCurrentCluster. */
     pxFile->ulAddrCurrentCluster = FF_TraverseFAT( pxIOManager, pxFile->ulObjectCluster, ulNewCluster, &( xTempError ) );
     pxFile->ulCurrentCluster = ulNewCluster;
     /* snip. */
+}

~~~
