### PR TITLE
Adding the Low Layer HAL module driver for STM32F4xx

### DIFF
--- a/portable/STM32F4xx/stm32f4xx_ll_sdmmc.c
+++ b/portable/STM32F4xx/stm32f4xx_ll_sdmmc.c
@@ -1,0 +1,511 @@
+/**
+ ******************************************************************************
+ * @file    stm32f4xx_ll_sdmmc.c
+ * @author  MCD Application Team
+ * @version V1.3.2
+ * @date    26-June-2015
+ * @brief   SDMMC Low Layer HAL module driver.
+ *
+ *          This file provides firmware functions to manage the following
+ *          functionalities of the SDMMC peripheral:
+ *           + Initialization/de-initialization functions
+ *           + I/O operation functions
+ *           + Peripheral Control functions
+ *           + Peripheral State functions
+ *
+ * @verbatim
+ * ==============================================================================
+ ##### SDMMC peripheral features #####
+ #####==============================================================================
+ #####[..] The SD/SDIO MMC card host interface (SDIO) provides an interface between the APB2
+ #####   peripheral bus and MultiMedia cards (MMCs), SD memory cards, SDIO cards and CE-ATA
+ #####   devices.
+ #####
+ #####[..] The SDIO features include the following:
+ #####   (+) Full compliance with MultiMedia Card System Specification Version 4.2. Card support
+ #####       for three different databus modes: 1-bit (default), 4-bit and 8-bit
+ #####   (+) Full compatibility with previous versions of MultiMedia Cards (forward compatibility)
+ #####   (+) Full compliance with SD Memory Card Specifications Version 2.0
+ #####   (+) Full compliance with SD I/O Card Specification Version 2.0: card support for two
+ #####       different data bus modes: 1-bit (default) and 4-bit
+ #####   (+) Full support of the CE-ATA features (full compliance with CE-ATA digital protocol
+ #####       Rev1.1)
+ #####   (+) Data transfer up to 48 MHz for the 8 bit mode
+ #####   (+) Data and command output enable signals to control external bidirectional drivers.
+ #####
+ #####
+ ##### How to use this driver #####
+ #####==============================================================================
+ #####[..]
+ #####This driver is a considered as a driver of service for external devices drivers
+ #####that interfaces with the SDIO peripheral.
+ #####According to the device used (SD card/ MMC card / SDIO card ...), a set of APIs
+ #####is used in the device's driver to perform SDIO operations and functionalities.
+ #####
+ #####This driver is almost transparent for the final user, it is only used to implement other
+ #####functionalities of the external device.
+ #####
+ #####[..]
+ #####(+) The SDIO clock (SDIOCLK = 48 MHz) is coming from a specific output of PLL
+ #####    (PLL48CLK). Before start working with SDIO peripheral make sure that the
+ #####    PLL is well configured.
+ #####    The SDIO peripheral uses two clock signals:
+ #####    (++) SDIO adapter clock (SDIOCLK = 48 MHz)
+ #####    (++) APB2 bus clock (PCLK2)
+ #####
+ #####    -@@- PCLK2 and SDIO_CK clock frequencies must respect the following condition:
+ #####         Frequency(PCLK2) >= (3 / 8 x Frequency(SDIO_CK))
+ #####
+ #####(+) Enable/Disable peripheral clock using RCC peripheral macros related to SDIO
+ #####    peripheral.
+ #####
+ #####(+) Enable the Power ON State using the SDIO_PowerState_ON(SDIOx)
+ #####    function and disable it using the function SDIO_PowerState_OFF(SDIOx).
+ #####
+ #####(+) Enable/Disable the clock using the __SDIO_ENABLE()/__SDIO_DISABLE() macros.
+ #####
+ #####(+) Enable/Disable the peripheral interrupts using the macros __SDIO_ENABLE_IT(hsdio, IT)
+ #####    and __SDIO_DISABLE_IT(hsdio, IT) if you need to use interrupt mode.
+ #####
+ #####(+) When using the DMA mode
+ #####    (++) Configure the DMA in the MSP layer of the external device
+ #####    (++) Active the needed channel Request
+ #####    (++) Enable the DMA using __SDIO_DMA_ENABLE() macro or Disable it using the macro
+ #####         __SDIO_DMA_DISABLE().
+ #####
+ #####(+) To control the CPSM (Command Path State Machine) and send
+ #####    commands to the card use the SDIO_SendCommand(SDIOx),
+ #####    SDIO_GetCommandResponse() and SDIO_GetResponse() functions. First, user has
+ #####    to fill the command structure (pointer to SDIO_CmdInitTypeDef) according
+ #####    to the selected command to be sent.
+ #####    The parameters that should be filled are:
+ #####     (++) Command Argument
+ #####     (++) Command Index
+ #####     (++) Command Response type
+ #####     (++) Command Wait
+ #####     (++) CPSM Status (Enable or Disable).
+ #####
+ #####    -@@- To check if the command is well received, read the SDIO_CMDRESP
+ #####        register using the SDIO_GetCommandResponse().
+ #####        The SDIO responses registers (SDIO_RESP1 to SDIO_RESP2), use the
+ #####        SDIO_GetResponse() function.
+ #####
+ #####(+) To control the DPSM (Data Path State Machine) and send/receive
+ #####     data to/from the card use the SDIO_DataConfig(), SDIO_GetDataCounter(),
+ #####    SDIO_ReadFIFO(), DIO_WriteFIFO() and SDIO_GetFIFOCount() functions.
+ #####
+ *** Read Operations ***
+ ***=======================
+ ***[..]
+ ***  (#) First, user has to fill the data structure (pointer to
+ ***      SDIO_DataInitTypeDef) according to the selected data type to be received.
+ ***      The parameters that should be filled are:
+ ***       (++) Data Timeout
+ ***       (++) Data Length
+ ***       (++) Data Block size
+ ***       (++) Data Transfer direction: should be from card (To SDIO)
+ ***       (++) Data Transfer mode
+ ***       (++) DPSM Status (Enable or Disable)
+ ***
+ ***  (#) Configure the SDIO resources to receive the data from the card
+ ***      according to selected transfer mode (Refer to Step 8, 9 and 10).
+ ***
+ ***  (#) Send the selected Read command (refer to step 11).
+ ***
+ ***  (#) Use the SDIO flags/interrupts to check the transfer status.
+ ***
+ *** Write Operations ***
+ ***========================
+ ***[..]
+ *** (#) First, user has to fill the data structure (pointer to
+ ***     SDIO_DataInitTypeDef) according to the selected data type to be received.
+ ***     The parameters that should be filled are:
+ ***      (++) Data Timeout
+ ***      (++) Data Length
+ ***      (++) Data Block size
+ ***      (++) Data Transfer direction:  should be to card (To CARD)
+ ***      (++) Data Transfer mode
+ ***      (++) DPSM Status (Enable or Disable)
+ ***
+ *** (#) Configure the SDIO resources to send the data to the card according to
+ ***     selected transfer mode.
+ ***
+ *** (#) Send the selected Write command.
+ ***
+ *** (#) Use the SDIO flags/interrupts to check the transfer status.
+ ***
+ ***@endverbatim
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************
+ */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f4xx_hal.h"
+
+/** @addtogroup STM32F4xx_HAL_Driver
+ * @{
+ */
+
+/** @defgroup SDMMC_LL SDMMC Low Layer
+ * @brief Low layer module for SD and MMC driver
+ * @{
+ */
+
+#if defined( HAL_SD_MODULE_ENABLED ) || defined( HAL_MMC_MODULE_ENABLED )
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup SDMMC_LL_Exported_Functions SDMMC_LL Exported Functions
+ * @{
+ */
+
+/** @defgroup HAL_SDMMC_LL_Group1 Initialization/de-initialization functions
+ *  @brief    Initialization and Configuration functions
+ *
+ * @verbatim
+ * ===============================================================================
+ ##### Initialization/de-initialization functions #####
+ #####===============================================================================
+ #####[..]  This section provides functions allowing to:
+ #####
+ #####@endverbatim
+ * @{
+ */
+
+/**
+ * @brief  Initializes the SDIO according to the specified
+ *         parameters in the SDIO_InitTypeDef and create the associated handle.
+ * @param  SDIOx: Pointer to SDIO register base
+ * @param  Init: SDIO initialization structure
+ * @retval HAL status
+ */
+    HAL_StatusTypeDef SDIO_Init( SDIO_TypeDef * SDIOx,
+                                 SDIO_InitTypeDef Init )
+    {
+        uint32_t tmpreg = 0;
+
+        /* Check the parameters */
+        assert_param( IS_SDIO_ALL_INSTANCE( SDIOx ) );
+        assert_param( IS_SDIO_CLOCK_EDGE( Init.ClockEdge ) );
+        assert_param( IS_SDIO_CLOCK_BYPASS( Init.ClockBypass ) );
+        assert_param( IS_SDIO_CLOCK_POWER_SAVE( Init.ClockPowerSave ) );
+        assert_param( IS_SDIO_BUS_WIDE( Init.BusWide ) );
+        assert_param( IS_SDIO_HARDWARE_FLOW_CONTROL( Init.HardwareFlowControl ) );
+        assert_param( IS_SDIO_CLKDIV( Init.ClockDiv ) );
+
+        /* Set SDIO configuration parameters */
+        tmpreg |= ( Init.ClockEdge |           \
+                    Init.ClockBypass |         \
+                    Init.ClockPowerSave |      \
+                    Init.BusWide |             \
+                    Init.HardwareFlowControl | \
+                    Init.ClockDiv
+                    );
+
+        /* Write to SDIO CLKCR */
+        MODIFY_REG( SDIOx->CLKCR, CLKCR_CLEAR_MASK, tmpreg );
+
+        return HAL_OK;
+    }
+
+/**
+ * @}
+ */
+
+/** @defgroup HAL_SDMMC_LL_Group2 I/O operation functions
+ *  @brief   Data transfers functions
+ *
+ * @verbatim
+ * ===============================================================================
+ ##### I/O operation functions #####
+ #####===============================================================================
+ #####[..]
+ #####This subsection provides a set of functions allowing to manage the SDIO data
+ #####transfers.
+ #####
+ #####@endverbatim
+ * @{
+ */
+
+/**
+ * @brief  Read data (word) from Rx FIFO in blocking mode (polling)
+ * @param  SDIOx: Pointer to SDIO register base
+ * @retval HAL status
+ */
+    uint32_t SDIO_ReadFIFO( SDIO_TypeDef * SDIOx )
+    {
+        /* Read data from Rx FIFO */
+        return( SDIOx->FIFO );
+    }
+
+/**
+ * @brief  Write data (word) to Tx FIFO in blocking mode (polling)
+ * @param  SDIOx: Pointer to SDIO register base
+ * @param  pWriteData: pointer to data to write
+ * @retval HAL status
+ */
+    HAL_StatusTypeDef SDIO_WriteFIFO( SDIO_TypeDef * SDIOx,
+                                      uint32_t * pWriteData )
+    {
+        /* Write data to FIFO */
+        SDIOx->FIFO = *pWriteData;
+
+        return HAL_OK;
+    }
+
+/**
+ * @}
+ */
+
+/** @defgroup HAL_SDMMC_LL_Group3 Peripheral Control functions
+ *  @brief   management functions
+ *
+ * @verbatim
+ * ===============================================================================
+ ##### Peripheral Control functions #####
+ #####===============================================================================
+ #####[..]
+ #####This subsection provides a set of functions allowing to control the SDIO data
+ #####transfers.
+ #####
+ #####@endverbatim
+ * @{
+ */
+
+/**
+ * @brief  Set SDIO Power state to ON.
+ * @param  SDIOx: Pointer to SDIO register base
+ * @retval HAL status
+ */
+    HAL_StatusTypeDef SDIO_PowerState_ON( SDIO_TypeDef * SDIOx )
+    {
+        /* Set power state to ON */
+        SDIOx->POWER = SDIO_POWER_PWRCTRL;
+
+        return HAL_OK;
+    }
+
+/**
+ * @brief  Set SDIO Power state to OFF.
+ * @param  SDIOx: Pointer to SDIO register base
+ * @retval HAL status
+ */
+    HAL_StatusTypeDef SDIO_PowerState_OFF( SDIO_TypeDef * SDIOx )
+    {
+        /* Set power state to OFF */
+        SDIOx->POWER = ( uint32_t ) 0x00000000;
+
+        return HAL_OK;
+    }
+
+/**
+ * @brief  Get SDIO Power state.
+ * @param  SDIOx: Pointer to SDIO register base
+ * @retval Power status of the controller. The returned value can be one of the
+ *         following values:
+ *            - 0x00: Power OFF
+ *            - 0x02: Power UP
+ *            - 0x03: Power ON
+ */
+    uint32_t SDIO_GetPowerState( SDIO_TypeDef * SDIOx )
+    {
+        return( SDIOx->POWER & SDIO_POWER_PWRCTRL );
+    }
+
+/**
+ * @brief  Configure the SDIO command path according to the specified parameters in
+ *         SDIO_CmdInitTypeDef structure and send the command
+ * @param  SDIOx: Pointer to SDIO register base
+ * @param  SDIO_CmdInitStruct: pointer to a SDIO_CmdInitTypeDef structure that contains
+ *         the configuration information for the SDIO command
+ * @retval HAL status
+ */
+    HAL_StatusTypeDef SDIO_SendCommand( SDIO_TypeDef * SDIOx,
+                                        SDIO_CmdInitTypeDef * SDIO_CmdInitStruct )
+    {
+        uint32_t tmpreg = 0;
+
+        /* Check the parameters */
+        assert_param( IS_SDIO_CMD_INDEX( SDIO_CmdInitStruct->CmdIndex ) );
+        assert_param( IS_SDIO_RESPONSE( SDIO_CmdInitStruct->Response ) );
+        assert_param( IS_SDIO_WAIT( SDIO_CmdInitStruct->WaitForInterrupt ) );
+        assert_param( IS_SDIO_CPSM( SDIO_CmdInitStruct->CPSM ) );
+
+        /* Set the SDIO Argument value */
+        SDIOx->ARG = SDIO_CmdInitStruct->Argument;
+
+        /* Set SDIO command parameters */
+        tmpreg |= ( uint32_t ) ( SDIO_CmdInitStruct->CmdIndex |         \
+                                 SDIO_CmdInitStruct->Response |         \
+                                 SDIO_CmdInitStruct->WaitForInterrupt | \
+                                 SDIO_CmdInitStruct->CPSM );
+
+        /* Write to SDIO CMD register */
+        MODIFY_REG( SDIOx->CMD, CMD_CLEAR_MASK, tmpreg );
+
+        return HAL_OK;
+    }
+
+/**
+ * @brief  Return the command index of last command for which response received
+ * @param  SDIOx: Pointer to SDIO register base
+ * @retval Command index of the last command response received
+ */
+    uint8_t SDIO_GetCommandResponse( SDIO_TypeDef * SDIOx )
+    {
+        return ( uint8_t ) ( SDIOx->RESPCMD );
+    }
+
+
+/**
+ * @brief  Return the response received from the card for the last command
+ * @param  SDIO_RESP: Specifies the SDIO response register.
+ *          This parameter can be one of the following values:
+ *            @arg SDIO_RESP1: Response Register 1
+ *            @arg SDIO_RESP2: Response Register 2
+ *            @arg SDIO_RESP3: Response Register 3
+ *            @arg SDIO_RESP4: Response Register 4
+ * @retval The Corresponding response register value
+ */
+    uint32_t SDIO_GetResponse( uint32_t SDIO_RESP )
+    {
+        __IO uint32_t tmp = 0;
+
+        /* Check the parameters */
+        assert_param( IS_SDIO_RESP( SDIO_RESP ) );
+
+        /* Get the response */
+        tmp = SDIO_RESP_ADDR + SDIO_RESP;
+
+        return( *( __IO uint32_t * ) tmp );
+    }
+
+/**
+ * @brief  Configure the SDIO data path according to the specified
+ *         parameters in the SDIO_DataInitTypeDef.
+ * @param  SDIOx: Pointer to SDIO register base
+ * @param  SDIO_DataInitStruct : pointer to a SDIO_DataInitTypeDef structure
+ *         that contains the configuration information for the SDIO command.
+ * @retval HAL status
+ */
+    HAL_StatusTypeDef SDIO_DataConfig( SDIO_TypeDef * SDIOx,
+                                       SDIO_DataInitTypeDef * SDIO_DataInitStruct )
+    {
+        uint32_t tmpreg = 0;
+
+        /* Check the parameters */
+        assert_param( IS_SDIO_DATA_LENGTH( SDIO_DataInitStruct->DataLength ) );
+        assert_param( IS_SDIO_BLOCK_SIZE( SDIO_DataInitStruct->DataBlockSize ) );
+        assert_param( IS_SDIO_TRANSFER_DIR( SDIO_DataInitStruct->TransferDir ) );
+        assert_param( IS_SDIO_TRANSFER_MODE( SDIO_DataInitStruct->TransferMode ) );
+        assert_param( IS_SDIO_DPSM( SDIO_DataInitStruct->DPSM ) );
+
+        /* Set the SDIO Data Timeout value */
+        SDIOx->DTIMER = SDIO_DataInitStruct->DataTimeOut;
+
+        /* Set the SDIO DataLength value */
+        SDIOx->DLEN = SDIO_DataInitStruct->DataLength;
+
+        /* Set the SDIO data configuration parameters */
+        tmpreg |= ( uint32_t ) ( SDIO_DataInitStruct->DataBlockSize | \
+                                 SDIO_DataInitStruct->TransferDir |   \
+                                 SDIO_DataInitStruct->TransferMode |  \
+                                 SDIO_DataInitStruct->DPSM );
+
+        /* Write to SDIO DCTRL */
+        /* CLEAR_MASK = SDIO_DCTRL_DTEN | SDIO_DCTRL_DTDIR | SDIO_DCTRL_DTMODE | SDIO_DCTRL_DBLOCKSIZE */
+
+        MODIFY_REG( SDIOx->DCTRL, DCTRL_CLEAR_MASK, tmpreg );
+
+        return HAL_OK;
+    }
+
+/**
+ * @brief  Returns number of remaining data bytes to be transferred.
+ * @param  SDIOx: Pointer to SDIO register base
+ * @retval Number of remaining data bytes to be transferred
+ */
+    uint32_t SDIO_GetDataCounter( SDIO_TypeDef * SDIOx )
+    {
+        return( SDIOx->DCOUNT );
+    }
+
+/**
+ * @brief  Get the FIFO data
+ * @param  SDIOx: Pointer to SDIO register base
+ * @retval Data received
+ */
+    uint32_t SDIO_GetFIFOCount( SDIO_TypeDef * SDIOx )
+    {
+        return( SDIOx->FIFO );
+    }
+
+
+/**
+ * @brief  Sets one of the two options of inserting read wait interval.
+ * @param  SDIO_ReadWaitMode: SD I/O Read Wait operation mode.
+ *          This parameter can be:
+ *            @arg SDIO_READ_WAIT_MODE_CLK: Read Wait control by stopping SDIOCLK
+ *            @arg SDIO_READ_WAIT_MODE_DATA2: Read Wait control using SDIO_DATA2
+ * @retval None
+ */
+    HAL_StatusTypeDef SDIO_SetSDIOReadWaitMode( uint32_t SDIO_ReadWaitMode )
+    {
+        /* Check the parameters */
+        assert_param( IS_SDIO_READWAIT_MODE( SDIO_ReadWaitMode ) );
+
+        *( __IO uint32_t * ) DCTRL_RWMOD_BB = SDIO_ReadWaitMode;
+
+        return HAL_OK;
+    }
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+#endif /* (HAL_SD_MODULE_ENABLED) || (HAL_MMC_MODULE_ENABLED) */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/portable/STM32F4xx/stm32f4xx_ll_sdmmc.h
+++ b/portable/STM32F4xx/stm32f4xx_ll_sdmmc.h
@@ -1,0 +1,957 @@
+/**
+ ******************************************************************************
+ * @file    stm32f4xx_ll_sdmmc.h
+ * @author  MCD Application Team
+ * @version V1.3.2
+ * @date    26-June-2015
+ * @brief   Header file of SDMMC HAL module.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F4xx_LL_SDMMC_H
+    #define __STM32F4xx_LL_SDMMC_H
+
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
+
+/* Includes ------------------------------------------------------------------*/
+    #include "stm32f4xx_hal_def.h"
+
+/** @addtogroup STM32F4xx_Driver
+ * @{
+ */
+
+/** @addtogroup SDMMC_LL
+ * @{
+ */
+
+/* Exported types ------------------------------------------------------------*/
+
+/** @defgroup SDMMC_LL_Exported_Types SDMMC_LL Exported Types
+ * @{
+ */
+
+/**
+ * @brief  SDMMC Configuration Structure definition
+ */
+    typedef struct
+    {
+        uint32_t ClockEdge;           /*!< Specifies the clock transition on which the bit capture is made.
+                                       *   This parameter can be a value of @ref SDIO_Clock_Edge                 */
+
+        uint32_t ClockBypass;         /*!< Specifies whether the SDIO Clock divider bypass is
+                                       *   enabled or disabled.
+                                       *   This parameter can be a value of @ref SDIO_Clock_Bypass               */
+
+        uint32_t ClockPowerSave;      /*!< Specifies whether SDIO Clock output is enabled or
+                                       *   disabled when the bus is idle.
+                                       *   This parameter can be a value of @ref SDIO_Clock_Power_Save           */
+
+        uint32_t BusWide;             /*!< Specifies the SDIO bus width.
+                                       *   This parameter can be a value of @ref SDIO_Bus_Wide                   */
+
+        uint32_t HardwareFlowControl; /*!< Specifies whether the SDIO hardware flow control is enabled or disabled.
+                                       *   This parameter can be a value of @ref SDIO_Hardware_Flow_Control      */
+
+        uint32_t ClockDiv;            /*!< Specifies the clock frequency of the SDIO controller.
+                                       *   This parameter can be a value between Min_Data = 0 and Max_Data = 255 */
+    } SDIO_InitTypeDef;
+
+
+/**
+ * @brief  SDIO Command Control structure
+ */
+    typedef struct
+    {
+        uint32_t Argument;         /*!< Specifies the SDIO command argument which is sent
+                                    *   to a card as part of a command message. If a command
+                                    *   contains an argument, it must be loaded into this register
+                                    *   before writing the command to the command register.              */
+
+        uint32_t CmdIndex;         /*!< Specifies the SDIO command index. It must be Min_Data = 0 and
+                                    *   Max_Data = 64                                                    */
+
+        uint32_t Response;         /*!< Specifies the SDIO response type.
+                                    *   This parameter can be a value of @ref SDIO_Response_Type         */
+
+        uint32_t WaitForInterrupt; /*!< Specifies whether SDIO wait for interrupt request is
+                                    *   enabled or disabled.
+                                    *   This parameter can be a value of @ref SDIO_Wait_Interrupt_State  */
+
+        uint32_t CPSM;             /*!< Specifies whether SDIO Command path state machine (CPSM)
+                                    *   is enabled or disabled.
+                                    *   This parameter can be a value of @ref SDIO_CPSM_State            */
+    } SDIO_CmdInitTypeDef;
+
+
+/**
+ * @brief  SDIO Data Control structure
+ */
+    typedef struct
+    {
+        uint32_t DataTimeOut;   /*!< Specifies the data timeout period in card bus clock periods.  */
+
+        uint32_t DataLength;    /*!< Specifies the number of data bytes to be transferred.         */
+
+        uint32_t DataBlockSize; /*!< Specifies the data block size for block transfer.
+                                 *   This parameter can be a value of @ref SDIO_Data_Block_Size    */
+
+        uint32_t TransferDir;   /*!< Specifies the data transfer direction, whether the transfer
+                                 *    is a read or write.
+                                 *    This parameter can be a value of @ref SDIO_Transfer_Direction */
+
+        uint32_t TransferMode;  /*!< Specifies whether data transfer is in stream or block mode.
+                                 *    This parameter can be a value of @ref SDIO_Transfer_Type      */
+
+        uint32_t DPSM;          /*!< Specifies whether SDIO Data path state machine (DPSM)
+                                 *   is enabled or disabled.
+                                 *   This parameter can be a value of @ref SDIO_DPSM_State         */
+    } SDIO_DataInitTypeDef;
+
+/**
+ * @}
+ */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup SDMMC_LL_Exported_Constants SDMMC_LL Exported Constants
+ * @{
+ */
+
+/** @defgroup SDIO_Clock_Edge Clock Edge
+ * @{
+ */
+    #define SDIO_CLOCK_EDGE_RISING     ( ( uint32_t ) 0x00000000 )
+    #define SDIO_CLOCK_EDGE_FALLING    SDIO_CLKCR_NEGEDGE
+
+    #define IS_SDIO_CLOCK_EDGE( EDGE )          \
+    ( ( ( EDGE ) == SDIO_CLOCK_EDGE_RISING ) || \
+      ( ( EDGE ) == SDIO_CLOCK_EDGE_FALLING ) )
+
+/**
+ * @}
+ */
+
+/** @defgroup SDIO_Clock_Bypass Clock Bypass
+ * @{
+ */
+    #define SDIO_CLOCK_BYPASS_DISABLE    ( ( uint32_t ) 0x00000000 )
+    #define SDIO_CLOCK_BYPASS_ENABLE     SDIO_CLKCR_BYPASS
+
+    #define IS_SDIO_CLOCK_BYPASS( BYPASS )           \
+    ( ( ( BYPASS ) == SDIO_CLOCK_BYPASS_DISABLE ) || \
+      ( ( BYPASS ) == SDIO_CLOCK_BYPASS_ENABLE ) )
+
+/**
+ * @}
+ */
+
+/** @defgroup SDIO_Clock_Power_Save Clock Power Saving
+ * @{
+ */
+    #define SDIO_CLOCK_POWER_SAVE_DISABLE    ( ( uint32_t ) 0x00000000 )
+    #define SDIO_CLOCK_POWER_SAVE_ENABLE     SDIO_CLKCR_PWRSAV
+
+    #define IS_SDIO_CLOCK_POWER_SAVE( SAVE )           \
+    ( ( ( SAVE ) == SDIO_CLOCK_POWER_SAVE_DISABLE ) || \
+      ( ( SAVE ) == SDIO_CLOCK_POWER_SAVE_ENABLE ) )
+
+/**
+ * @}
+ */
+
+/** @defgroup SDIO_Bus_Wide Bus Width
+ * @{
+ */
+    #define SDIO_BUS_WIDE_1B    ( ( uint32_t ) 0x00000000 )
+    #define SDIO_BUS_WIDE_4B    SDIO_CLKCR_WIDBUS_0
+    #define SDIO_BUS_WIDE_8B    SDIO_CLKCR_WIDBUS_1
+
+    #define IS_SDIO_BUS_WIDE( WIDE )      \
+    ( ( ( WIDE ) == SDIO_BUS_WIDE_1B ) || \
+      ( ( WIDE ) == SDIO_BUS_WIDE_4B ) || \
+      ( ( WIDE ) == SDIO_BUS_WIDE_8B ) )
+
+/**
+ * @}
+ */
+
+/** @defgroup SDIO_Hardware_Flow_Control Hardware Flow Control
+ * @{
+ */
+    #define SDIO_HARDWARE_FLOW_CONTROL_DISABLE    ( ( uint32_t ) 0x00000000 )
+    #define SDIO_HARDWARE_FLOW_CONTROL_ENABLE     SDIO_CLKCR_HWFC_EN
+
+    #define IS_SDIO_HARDWARE_FLOW_CONTROL( CONTROL )           \
+    ( ( ( CONTROL ) == SDIO_HARDWARE_FLOW_CONTROL_DISABLE ) || \
+      ( ( CONTROL ) == SDIO_HARDWARE_FLOW_CONTROL_ENABLE ) )
+
+/**
+ * @}
+ */
+
+/** @defgroup SDIO_Clock_Division Clock Division
+ * @{
+ */
+    #define IS_SDIO_CLKDIV( DIV )    ( ( DIV ) <= 0xFF )
+
+/**
+ * @}
+ */
+
+/** @defgroup SDIO_Command_Index Command Index
+ * @{
+ */
+    #define IS_SDIO_CMD_INDEX( INDEX )    ( ( INDEX ) < 0x40 )
+
+/**
+ * @}
+ */
+
+/** @defgroup SDIO_Response_Type Response Type
+ * @{
+ */
+    #define SDIO_RESPONSE_NO       ( ( uint32_t ) 0x00000000 )
+    #define SDIO_RESPONSE_SHORT    SDIO_CMD_WAITRESP_0
+    #define SDIO_RESPONSE_LONG     SDIO_CMD_WAITRESP
+
+    #define IS_SDIO_RESPONSE( RESPONSE )         \
+    ( ( ( RESPONSE ) == SDIO_RESPONSE_NO ) ||    \
+      ( ( RESPONSE ) == SDIO_RESPONSE_SHORT ) || \
+      ( ( RESPONSE ) == SDIO_RESPONSE_LONG ) )
+
+/**
+ * @}
+ */
+
+/** @defgroup SDIO_Wait_Interrupt_State Wait Interrupt
+ * @{
+ */
+    #define SDIO_WAIT_NO      ( ( uint32_t ) 0x00000000 )
+    #define SDIO_WAIT_IT      SDIO_CMD_WAITINT
+    #define SDIO_WAIT_PEND    SDIO_CMD_WAITPEND
+
+    #define IS_SDIO_WAIT( WAIT )      \
+    ( ( ( WAIT ) == SDIO_WAIT_NO ) || \
+      ( ( WAIT ) == SDIO_WAIT_IT ) || \
+      ( ( WAIT ) == SDIO_WAIT_PEND ) )
+
+/**
+ * @}
+ */
+
+/** @defgroup SDIO_CPSM_State CPSM State
+ * @{
+ */
+    #define SDIO_CPSM_DISABLE    ( ( uint32_t ) 0x00000000 )
+    #define SDIO_CPSM_ENABLE     SDIO_CMD_CPSMEN
+
+    #define IS_SDIO_CPSM( CPSM )           \
+    ( ( ( CPSM ) == SDIO_CPSM_DISABLE ) || \
+      ( ( CPSM ) == SDIO_CPSM_ENABLE ) )
+
+/**
+ * @}
+ */
+
+/** @defgroup SDIO_Response_Registers Response Register
+ * @{
+ */
+    #define SDIO_RESP1    ( ( uint32_t ) 0x00000000 )
+    #define SDIO_RESP2    ( ( uint32_t ) 0x00000004 )
+    #define SDIO_RESP3    ( ( uint32_t ) 0x00000008 )
+    #define SDIO_RESP4    ( ( uint32_t ) 0x0000000C )
+
+    #define IS_SDIO_RESP( RESP )    \
+    ( ( ( RESP ) == SDIO_RESP1 ) || \
+      ( ( RESP ) == SDIO_RESP2 ) || \
+      ( ( RESP ) == SDIO_RESP3 ) || \
+      ( ( RESP ) == SDIO_RESP4 ) )
+
+/**
+ * @}
+ */
+
+/** @defgroup SDIO_Data_Length Data Lenght
+ * @{
+ */
+    #define IS_SDIO_DATA_LENGTH( LENGTH )    ( ( LENGTH ) <= 0x01FFFFFF )
+
+/**
+ * @}
+ */
+
+/** @defgroup SDIO_Data_Block_Size Data Block Size
+ * @{
+ */
+    #define SDIO_DATABLOCK_SIZE_1B        ( ( uint32_t ) 0x00000000 )
+    #define SDIO_DATABLOCK_SIZE_2B        SDIO_DCTRL_DBLOCKSIZE_0
+    #define SDIO_DATABLOCK_SIZE_4B        SDIO_DCTRL_DBLOCKSIZE_1
+    #define SDIO_DATABLOCK_SIZE_8B        ( ( uint32_t ) 0x00000030 )
+    #define SDIO_DATABLOCK_SIZE_16B       SDIO_DCTRL_DBLOCKSIZE_2
+    #define SDIO_DATABLOCK_SIZE_32B       ( ( uint32_t ) 0x00000050 )
+    #define SDIO_DATABLOCK_SIZE_64B       ( ( uint32_t ) 0x00000060 )
+    #define SDIO_DATABLOCK_SIZE_128B      ( ( uint32_t ) 0x00000070 )
+    #define SDIO_DATABLOCK_SIZE_256B      SDIO_DCTRL_DBLOCKSIZE_3
+    #define SDIO_DATABLOCK_SIZE_512B      ( ( uint32_t ) 0x00000090 )
+    #define SDIO_DATABLOCK_SIZE_1024B     ( ( uint32_t ) 0x000000A0 )
+    #define SDIO_DATABLOCK_SIZE_2048B     ( ( uint32_t ) 0x000000B0 )
+    #define SDIO_DATABLOCK_SIZE_4096B     ( ( uint32_t ) 0x000000C0 )
+    #define SDIO_DATABLOCK_SIZE_8192B     ( ( uint32_t ) 0x000000D0 )
+    #define SDIO_DATABLOCK_SIZE_16384B    ( ( uint32_t ) 0x000000E0 )
+
+    #define IS_SDIO_BLOCK_SIZE( SIZE )             \
+    ( ( ( SIZE ) == SDIO_DATABLOCK_SIZE_1B ) ||    \
+      ( ( SIZE ) == SDIO_DATABLOCK_SIZE_2B ) ||    \
+      ( ( SIZE ) == SDIO_DATABLOCK_SIZE_4B ) ||    \
+      ( ( SIZE ) == SDIO_DATABLOCK_SIZE_8B ) ||    \
+      ( ( SIZE ) == SDIO_DATABLOCK_SIZE_16B ) ||   \
+      ( ( SIZE ) == SDIO_DATABLOCK_SIZE_32B ) ||   \
+      ( ( SIZE ) == SDIO_DATABLOCK_SIZE_64B ) ||   \
+      ( ( SIZE ) == SDIO_DATABLOCK_SIZE_128B ) ||  \
+      ( ( SIZE ) == SDIO_DATABLOCK_SIZE_256B ) ||  \
+      ( ( SIZE ) == SDIO_DATABLOCK_SIZE_512B ) ||  \
+      ( ( SIZE ) == SDIO_DATABLOCK_SIZE_1024B ) || \
+      ( ( SIZE ) == SDIO_DATABLOCK_SIZE_2048B ) || \
+      ( ( SIZE ) == SDIO_DATABLOCK_SIZE_4096B ) || \
+      ( ( SIZE ) == SDIO_DATABLOCK_SIZE_8192B ) || \
+      ( ( SIZE ) == SDIO_DATABLOCK_SIZE_16384B ) )
+
+/**
+ * @}
+ */
+
+/** @defgroup SDIO_Transfer_Direction Transfer Direction
+ * @{
+ */
+    #define SDIO_TRANSFER_DIR_TO_CARD    ( ( uint32_t ) 0x00000000 )
+    #define SDIO_TRANSFER_DIR_TO_SDIO    SDIO_DCTRL_DTDIR
+
+    #define IS_SDIO_TRANSFER_DIR( DIR )           \
+    ( ( ( DIR ) == SDIO_TRANSFER_DIR_TO_CARD ) || \
+      ( ( DIR ) == SDIO_TRANSFER_DIR_TO_SDIO ) )
+
+/**
+ * @}
+ */
+
+/** @defgroup SDIO_Transfer_Type Transfer Type
+ * @{
+ */
+    #define SDIO_TRANSFER_MODE_BLOCK     ( ( uint32_t ) 0x00000000 )
+    #define SDIO_TRANSFER_MODE_STREAM    SDIO_DCTRL_DTMODE
+
+    #define IS_SDIO_TRANSFER_MODE( MODE )         \
+    ( ( ( MODE ) == SDIO_TRANSFER_MODE_BLOCK ) || \
+      ( ( MODE ) == SDIO_TRANSFER_MODE_STREAM ) )
+
+/**
+ * @}
+ */
+
+/** @defgroup SDIO_DPSM_State DPSM State
+ * @{
+ */
+    #define SDIO_DPSM_DISABLE    ( ( uint32_t ) 0x00000000 )
+    #define SDIO_DPSM_ENABLE     SDIO_DCTRL_DTEN
+
+    #define IS_SDIO_DPSM( DPSM )           \
+    ( ( ( DPSM ) == SDIO_DPSM_DISABLE ) || \
+      ( ( DPSM ) == SDIO_DPSM_ENABLE ) )
+
+/**
+ * @}
+ */
+
+/** @defgroup SDIO_Read_Wait_Mode Read Wait Mode
+ * @{
+ */
+    #define SDIO_READ_WAIT_MODE_DATA2    ( ( uint32_t ) 0x00000000 )
+    #define SDIO_READ_WAIT_MODE_CLK      ( ( uint32_t ) 0x00000001 )
+
+    #define IS_SDIO_READWAIT_MODE( MODE )        \
+    ( ( ( MODE ) == SDIO_READ_WAIT_MODE_CLK ) || \
+      ( ( MODE ) == SDIO_READ_WAIT_MODE_DATA2 ) )
+
+/**
+ * @}
+ */
+
+/** @defgroup SDIO_Interrupt_sources Interrupt Sources
+ * @{
+ */
+    #define SDIO_IT_CCRCFAIL    SDIO_STA_CCRCFAIL
+    #define SDIO_IT_DCRCFAIL    SDIO_STA_DCRCFAIL
+    #define SDIO_IT_CTIMEOUT    SDIO_STA_CTIMEOUT
+    #define SDIO_IT_DTIMEOUT    SDIO_STA_DTIMEOUT
+    #define SDIO_IT_TXUNDERR    SDIO_STA_TXUNDERR
+    #define SDIO_IT_RXOVERR     SDIO_STA_RXOVERR
+    #define SDIO_IT_CMDREND     SDIO_STA_CMDREND
+    #define SDIO_IT_CMDSENT     SDIO_STA_CMDSENT
+    #define SDIO_IT_DATAEND     SDIO_STA_DATAEND
+    #define SDIO_IT_STBITERR    SDIO_STA_STBITERR
+    #define SDIO_IT_DBCKEND     SDIO_STA_DBCKEND
+    #define SDIO_IT_CMDACT      SDIO_STA_CMDACT
+    #define SDIO_IT_TXACT       SDIO_STA_TXACT
+    #define SDIO_IT_RXACT       SDIO_STA_RXACT
+    #define SDIO_IT_TXFIFOHE    SDIO_STA_TXFIFOHE
+    #define SDIO_IT_RXFIFOHF    SDIO_STA_RXFIFOHF
+    #define SDIO_IT_TXFIFOF     SDIO_STA_TXFIFOF
+    #define SDIO_IT_RXFIFOF     SDIO_STA_RXFIFOF
+    #define SDIO_IT_TXFIFOE     SDIO_STA_TXFIFOE
+    #define SDIO_IT_RXFIFOE     SDIO_STA_RXFIFOE
+    #define SDIO_IT_TXDAVL      SDIO_STA_TXDAVL
+    #define SDIO_IT_RXDAVL      SDIO_STA_RXDAVL
+    #define SDIO_IT_SDIOIT      SDIO_STA_SDIOIT
+    #define SDIO_IT_CEATAEND    SDIO_STA_CEATAEND
+
+/**
+ * @}
+ */
+
+/** @defgroup SDIO_Flags Flags
+ * @{
+ */
+    #define SDIO_FLAG_CCRCFAIL    SDIO_STA_CCRCFAIL
+    #define SDIO_FLAG_DCRCFAIL    SDIO_STA_DCRCFAIL
+    #define SDIO_FLAG_CTIMEOUT    SDIO_STA_CTIMEOUT
+    #define SDIO_FLAG_DTIMEOUT    SDIO_STA_DTIMEOUT
+    #define SDIO_FLAG_TXUNDERR    SDIO_STA_TXUNDERR
+    #define SDIO_FLAG_RXOVERR     SDIO_STA_RXOVERR
+    #define SDIO_FLAG_CMDREND     SDIO_STA_CMDREND
+    #define SDIO_FLAG_CMDSENT     SDIO_STA_CMDSENT
+    #define SDIO_FLAG_DATAEND     SDIO_STA_DATAEND
+    #define SDIO_FLAG_STBITERR    SDIO_STA_STBITERR
+    #define SDIO_FLAG_DBCKEND     SDIO_STA_DBCKEND
+    #define SDIO_FLAG_CMDACT      SDIO_STA_CMDACT
+    #define SDIO_FLAG_TXACT       SDIO_STA_TXACT
+    #define SDIO_FLAG_RXACT       SDIO_STA_RXACT
+    #define SDIO_FLAG_TXFIFOHE    SDIO_STA_TXFIFOHE
+    #define SDIO_FLAG_RXFIFOHF    SDIO_STA_RXFIFOHF
+    #define SDIO_FLAG_TXFIFOF     SDIO_STA_TXFIFOF
+    #define SDIO_FLAG_RXFIFOF     SDIO_STA_RXFIFOF
+    #define SDIO_FLAG_TXFIFOE     SDIO_STA_TXFIFOE
+    #define SDIO_FLAG_RXFIFOE     SDIO_STA_RXFIFOE
+    #define SDIO_FLAG_TXDAVL      SDIO_STA_TXDAVL
+    #define SDIO_FLAG_RXDAVL      SDIO_STA_RXDAVL
+    #define SDIO_FLAG_SDIOIT      SDIO_STA_SDIOIT
+    #define SDIO_FLAG_CEATAEND    SDIO_STA_CEATAEND
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+/* Exported macro ------------------------------------------------------------*/
+
+/** @defgroup SDMMC_LL_Exported_macros SDMMC_LL Exported Macros
+ * @{
+ */
+
+/** @defgroup SDMMC_LL_Alias_Region Bit Address in the alias region
+ * @{
+ */
+/* ------------ SDIO registers bit address in the alias region -------------- */
+    #define SDIO_OFFSET    ( SDIO_BASE - PERIPH_BASE )
+
+/* --- CLKCR Register ---*/
+/* Alias word address of CLKEN bit */
+    #define CLKCR_OFFSET       ( SDIO_OFFSET + 0x04 )
+    #define CLKEN_BITNUMBER    0x08
+    #define CLKCR_CLKEN_BB     ( PERIPH_BB_BASE + ( CLKCR_OFFSET * 32 ) + ( CLKEN_BITNUMBER * 4 ) )
+
+/* --- CMD Register ---*/
+/* Alias word address of SDIOSUSPEND bit */
+    #define CMD_OFFSET               ( SDIO_OFFSET + 0x0C )
+    #define SDIOSUSPEND_BITNUMBER    0x0B
+    #define CMD_SDIOSUSPEND_BB       ( PERIPH_BB_BASE + ( CMD_OFFSET * 32 ) + ( SDIOSUSPEND_BITNUMBER * 4 ) )
+
+/* Alias word address of ENCMDCOMPL bit */
+    #define ENCMDCOMPL_BITNUMBER     0x0C
+    #define CMD_ENCMDCOMPL_BB        ( PERIPH_BB_BASE + ( CMD_OFFSET * 32 ) + ( ENCMDCOMPL_BITNUMBER * 4 ) )
+
+/* Alias word address of NIEN bit */
+    #define NIEN_BITNUMBER           0x0D
+    #define CMD_NIEN_BB              ( PERIPH_BB_BASE + ( CMD_OFFSET * 32 ) + ( NIEN_BITNUMBER * 4 ) )
+
+/* Alias word address of ATACMD bit */
+    #define ATACMD_BITNUMBER         0x0E
+    #define CMD_ATACMD_BB            ( PERIPH_BB_BASE + ( CMD_OFFSET * 32 ) + ( ATACMD_BITNUMBER * 4 ) )
+
+/* --- DCTRL Register ---*/
+/* Alias word address of DMAEN bit */
+    #define DCTRL_OFFSET         ( SDIO_OFFSET + 0x2C )
+    #define DMAEN_BITNUMBER      0x03
+    #define DCTRL_DMAEN_BB       ( PERIPH_BB_BASE + ( DCTRL_OFFSET * 32 ) + ( DMAEN_BITNUMBER * 4 ) )
+
+/* Alias word address of RWSTART bit */
+    #define RWSTART_BITNUMBER    0x08
+    #define DCTRL_RWSTART_BB     ( PERIPH_BB_BASE + ( DCTRL_OFFSET * 32 ) + ( RWSTART_BITNUMBER * 4 ) )
+
+/* Alias word address of RWSTOP bit */
+    #define RWSTOP_BITNUMBER     0x09
+    #define DCTRL_RWSTOP_BB      ( PERIPH_BB_BASE + ( DCTRL_OFFSET * 32 ) + ( RWSTOP_BITNUMBER * 4 ) )
+
+/* Alias word address of RWMOD bit */
+    #define RWMOD_BITNUMBER      0x0A
+    #define DCTRL_RWMOD_BB       ( PERIPH_BB_BASE + ( DCTRL_OFFSET * 32 ) + ( RWMOD_BITNUMBER * 4 ) )
+
+/* Alias word address of SDIOEN bit */
+    #define SDIOEN_BITNUMBER     0x0B
+    #define DCTRL_SDIOEN_BB      ( PERIPH_BB_BASE + ( DCTRL_OFFSET * 32 ) + ( SDIOEN_BITNUMBER * 4 ) )
+
+/**
+ * @}
+ */
+
+/** @defgroup SDMMC_LL_Register Bits And Addresses Definitions
+ * @brief SDMMC_LL registers bit address in the alias region
+ * @{
+ */
+
+/* ---------------------- SDIO registers bit mask --------------------------- */
+/* --- CLKCR Register ---*/
+/* CLKCR register clear mask */
+    #define CLKCR_CLEAR_MASK                                 \
+    ( ( uint32_t ) ( SDIO_CLKCR_CLKDIV | SDIO_CLKCR_PWRSAV | \
+                     SDIO_CLKCR_BYPASS | SDIO_CLKCR_WIDBUS | \
+                     SDIO_CLKCR_NEGEDGE | SDIO_CLKCR_HWFC_EN ) )
+
+/* --- PWRCTRL Register ---*/
+/* --- DCTRL Register ---*/
+/* SDIO DCTRL Clear Mask */
+    #define DCTRL_CLEAR_MASK                              \
+    ( ( uint32_t ) ( SDIO_DCTRL_DTEN | SDIO_DCTRL_DTDIR | \
+                     SDIO_DCTRL_DTMODE | SDIO_DCTRL_DBLOCKSIZE ) )
+
+/* --- CMD Register ---*/
+/* CMD Register clear mask */
+    #define CMD_CLEAR_MASK                                   \
+    ( ( uint32_t ) ( SDIO_CMD_CMDINDEX | SDIO_CMD_WAITRESP | \
+                     SDIO_CMD_WAITINT | SDIO_CMD_WAITPEND |  \
+                     SDIO_CMD_CPSMEN | SDIO_CMD_SDIOSUSPEND ) )
+
+/* SDIO RESP Registers Address */
+    #define SDIO_RESP_ADDR           ( ( uint32_t ) ( SDIO_BASE + 0x14 ) )
+
+/* SDIO Initialization Frequency (400KHz max) */
+    #define SDIO_INIT_CLK_DIV        ( ( uint8_t ) 0x76 )
+
+/* SDIO Data Transfer Frequency (25MHz max) */
+    #define SDIO_TRANSFER_CLK_DIV    ( ( uint8_t ) 0x0 )
+
+/**
+ * @}
+ */
+
+/** @defgroup SDMMC_LL_Interrupt_Clock Interrupt And Clock Configuration
+ * @brief macros to handle interrupts and specific clock configurations
+ * @{
+ */
+
+/**
+ * @brief  Enable the SDIO device.
+ * @retval None
+ */
+    #define __SDIO_ENABLE()                                     ( *( __IO uint32_t * ) CLKCR_CLKEN_BB = ENABLE )
+
+/**
+ * @brief  Disable the SDIO device.
+ * @retval None
+ */
+    #define __SDIO_DISABLE()                                    ( *( __IO uint32_t * ) CLKCR_CLKEN_BB = DISABLE )
+
+/**
+ * @brief  Enable the SDIO DMA transfer.
+ * @retval None
+ */
+    #define __SDIO_DMA_ENABLE()                                 ( *( __IO uint32_t * ) DCTRL_DMAEN_BB = ENABLE )
+
+/**
+ * @brief  Disable the SDIO DMA transfer.
+ * @retval None
+ */
+    #define __SDIO_DMA_DISABLE()                                ( *( __IO uint32_t * ) DCTRL_DMAEN_BB = DISABLE )
+
+/**
+ * @brief  Enable the SDIO device interrupt.
+ * @param  __INSTANCE__ : Pointer to SDIO register base
+ * @param  __INTERRUPT__ : specifies the SDIO interrupt sources to be enabled.
+ *         This parameter can be one or a combination of the following values:
+ *            @arg SDIO_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
+ *            @arg SDIO_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
+ *            @arg SDIO_IT_CTIMEOUT: Command response timeout interrupt
+ *            @arg SDIO_IT_DTIMEOUT: Data timeout interrupt
+ *            @arg SDIO_IT_TXUNDERR: Transmit FIFO underrun error interrupt
+ *            @arg SDIO_IT_RXOVERR:  Received FIFO overrun error interrupt
+ *            @arg SDIO_IT_CMDREND:  Command response received (CRC check passed) interrupt
+ *            @arg SDIO_IT_CMDSENT:  Command sent (no response required) interrupt
+ *            @arg SDIO_IT_DATAEND:  Data end (data counter, SDIDCOUNT, is zero) interrupt
+ *            @arg SDIO_IT_STBITERR: Start bit not detected on all data signals in wide
+ *                                   bus mode interrupt
+ *            @arg SDIO_IT_DBCKEND:  Data block sent/received (CRC check passed) interrupt
+ *            @arg SDIO_IT_CMDACT:   Command transfer in progress interrupt
+ *            @arg SDIO_IT_TXACT:    Data transmit in progress interrupt
+ *            @arg SDIO_IT_RXACT:    Data receive in progress interrupt
+ *            @arg SDIO_IT_TXFIFOHE: Transmit FIFO Half Empty interrupt
+ *            @arg SDIO_IT_RXFIFOHF: Receive FIFO Half Full interrupt
+ *            @arg SDIO_IT_TXFIFOF:  Transmit FIFO full interrupt
+ *            @arg SDIO_IT_RXFIFOF:  Receive FIFO full interrupt
+ *            @arg SDIO_IT_TXFIFOE:  Transmit FIFO empty interrupt
+ *            @arg SDIO_IT_RXFIFOE:  Receive FIFO empty interrupt
+ *            @arg SDIO_IT_TXDAVL:   Data available in transmit FIFO interrupt
+ *            @arg SDIO_IT_RXDAVL:   Data available in receive FIFO interrupt
+ *            @arg SDIO_IT_SDIOIT:   SD I/O interrupt received interrupt
+ *            @arg SDIO_IT_CEATAEND: CE-ATA command completion signal received for CMD61 interrupt
+ * @retval None
+ */
+    #define __SDIO_ENABLE_IT( __INSTANCE__, __INTERRUPT__ )     ( ( __INSTANCE__ )->MASK |= ( __INTERRUPT__ ) )
+
+/**
+ * @brief  Disable the SDIO device interrupt.
+ * @param  __INSTANCE__ : Pointer to SDIO register base
+ * @param  __INTERRUPT__ : specifies the SDIO interrupt sources to be disabled.
+ *          This parameter can be one or a combination of the following values:
+ *            @arg SDIO_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
+ *            @arg SDIO_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
+ *            @arg SDIO_IT_CTIMEOUT: Command response timeout interrupt
+ *            @arg SDIO_IT_DTIMEOUT: Data timeout interrupt
+ *            @arg SDIO_IT_TXUNDERR: Transmit FIFO underrun error interrupt
+ *            @arg SDIO_IT_RXOVERR:  Received FIFO overrun error interrupt
+ *            @arg SDIO_IT_CMDREND:  Command response received (CRC check passed) interrupt
+ *            @arg SDIO_IT_CMDSENT:  Command sent (no response required) interrupt
+ *            @arg SDIO_IT_DATAEND:  Data end (data counter, SDIDCOUNT, is zero) interrupt
+ *            @arg SDIO_IT_STBITERR: Start bit not detected on all data signals in wide
+ *                                   bus mode interrupt
+ *            @arg SDIO_IT_DBCKEND:  Data block sent/received (CRC check passed) interrupt
+ *            @arg SDIO_IT_CMDACT:   Command transfer in progress interrupt
+ *            @arg SDIO_IT_TXACT:    Data transmit in progress interrupt
+ *            @arg SDIO_IT_RXACT:    Data receive in progress interrupt
+ *            @arg SDIO_IT_TXFIFOHE: Transmit FIFO Half Empty interrupt
+ *            @arg SDIO_IT_RXFIFOHF: Receive FIFO Half Full interrupt
+ *            @arg SDIO_IT_TXFIFOF:  Transmit FIFO full interrupt
+ *            @arg SDIO_IT_RXFIFOF:  Receive FIFO full interrupt
+ *            @arg SDIO_IT_TXFIFOE:  Transmit FIFO empty interrupt
+ *            @arg SDIO_IT_RXFIFOE:  Receive FIFO empty interrupt
+ *            @arg SDIO_IT_TXDAVL:   Data available in transmit FIFO interrupt
+ *            @arg SDIO_IT_RXDAVL:   Data available in receive FIFO interrupt
+ *            @arg SDIO_IT_SDIOIT:   SD I/O interrupt received interrupt
+ *            @arg SDIO_IT_CEATAEND: CE-ATA command completion signal received for CMD61 interrupt
+ * @retval None
+ */
+    #define __SDIO_DISABLE_IT( __INSTANCE__, __INTERRUPT__ )    ( ( __INSTANCE__ )->MASK &= ~( __INTERRUPT__ ) )
+
+/**
+ * @brief  Checks whether the specified SDIO flag is set or not.
+ * @param  __INSTANCE__ : Pointer to SDIO register base
+ * @param  __FLAG__: specifies the flag to check.
+ *          This parameter can be one of the following values:
+ *            @arg SDIO_FLAG_CCRCFAIL: Command response received (CRC check failed)
+ *            @arg SDIO_FLAG_DCRCFAIL: Data block sent/received (CRC check failed)
+ *            @arg SDIO_FLAG_CTIMEOUT: Command response timeout
+ *            @arg SDIO_FLAG_DTIMEOUT: Data timeout
+ *            @arg SDIO_FLAG_TXUNDERR: Transmit FIFO underrun error
+ *            @arg SDIO_FLAG_RXOVERR:  Received FIFO overrun error
+ *            @arg SDIO_FLAG_CMDREND:  Command response received (CRC check passed)
+ *            @arg SDIO_FLAG_CMDSENT:  Command sent (no response required)
+ *            @arg SDIO_FLAG_DATAEND:  Data end (data counter, SDIDCOUNT, is zero)
+ *            @arg SDIO_FLAG_STBITERR: Start bit not detected on all data signals in wide bus mode.
+ *            @arg SDIO_FLAG_DBCKEND:  Data block sent/received (CRC check passed)
+ *            @arg SDIO_FLAG_CMDACT:   Command transfer in progress
+ *            @arg SDIO_FLAG_TXACT:    Data transmit in progress
+ *            @arg SDIO_FLAG_RXACT:    Data receive in progress
+ *            @arg SDIO_FLAG_TXFIFOHE: Transmit FIFO Half Empty
+ *            @arg SDIO_FLAG_RXFIFOHF: Receive FIFO Half Full
+ *            @arg SDIO_FLAG_TXFIFOF:  Transmit FIFO full
+ *            @arg SDIO_FLAG_RXFIFOF:  Receive FIFO full
+ *            @arg SDIO_FLAG_TXFIFOE:  Transmit FIFO empty
+ *            @arg SDIO_FLAG_RXFIFOE:  Receive FIFO empty
+ *            @arg SDIO_FLAG_TXDAVL:   Data available in transmit FIFO
+ *            @arg SDIO_FLAG_RXDAVL:   Data available in receive FIFO
+ *            @arg SDIO_FLAG_SDIOIT:   SD I/O interrupt received
+ *            @arg SDIO_FLAG_CEATAEND: CE-ATA command completion signal received for CMD61
+ * @retval The new state of SDIO_FLAG (SET or RESET).
+ */
+    #define __SDIO_GET_FLAG( __INSTANCE__, __FLAG__ )           ( ( ( __INSTANCE__ )->STA & ( __FLAG__ ) ) != RESET )
+
+
+/**
+ * @brief  Clears the SDIO pending flags.
+ * @param  __INSTANCE__ : Pointer to SDIO register base
+ * @param  __FLAG__: specifies the flag to clear.
+ *          This parameter can be one or a combination of the following values:
+ *            @arg SDIO_FLAG_CCRCFAIL: Command response received (CRC check failed)
+ *            @arg SDIO_FLAG_DCRCFAIL: Data block sent/received (CRC check failed)
+ *            @arg SDIO_FLAG_CTIMEOUT: Command response timeout
+ *            @arg SDIO_FLAG_DTIMEOUT: Data timeout
+ *            @arg SDIO_FLAG_TXUNDERR: Transmit FIFO underrun error
+ *            @arg SDIO_FLAG_RXOVERR:  Received FIFO overrun error
+ *            @arg SDIO_FLAG_CMDREND:  Command response received (CRC check passed)
+ *            @arg SDIO_FLAG_CMDSENT:  Command sent (no response required)
+ *            @arg SDIO_FLAG_DATAEND:  Data end (data counter, SDIDCOUNT, is zero)
+ *            @arg SDIO_FLAG_STBITERR: Start bit not detected on all data signals in wide bus mode
+ *            @arg SDIO_FLAG_DBCKEND:  Data block sent/received (CRC check passed)
+ *            @arg SDIO_FLAG_SDIOIT:   SD I/O interrupt received
+ *            @arg SDIO_FLAG_CEATAEND: CE-ATA command completion signal received for CMD61
+ * @retval None
+ */
+    #define __SDIO_CLEAR_FLAG( __INSTANCE__, __FLAG__ )    ( ( __INSTANCE__ )->ICR = ( __FLAG__ ) )
+
+/**
+ * @brief  Checks whether the specified SDIO interrupt has occurred or not.
+ * @param  __INSTANCE__ : Pointer to SDIO register base
+ * @param  __INTERRUPT__: specifies the SDIO interrupt source to check.
+ *          This parameter can be one of the following values:
+ *            @arg SDIO_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
+ *            @arg SDIO_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
+ *            @arg SDIO_IT_CTIMEOUT: Command response timeout interrupt
+ *            @arg SDIO_IT_DTIMEOUT: Data timeout interrupt
+ *            @arg SDIO_IT_TXUNDERR: Transmit FIFO underrun error interrupt
+ *            @arg SDIO_IT_RXOVERR:  Received FIFO overrun error interrupt
+ *            @arg SDIO_IT_CMDREND:  Command response received (CRC check passed) interrupt
+ *            @arg SDIO_IT_CMDSENT:  Command sent (no response required) interrupt
+ *            @arg SDIO_IT_DATAEND:  Data end (data counter, SDIDCOUNT, is zero) interrupt
+ *            @arg SDIO_IT_STBITERR: Start bit not detected on all data signals in wide
+ *                                   bus mode interrupt
+ *            @arg SDIO_IT_DBCKEND:  Data block sent/received (CRC check passed) interrupt
+ *            @arg SDIO_IT_CMDACT:   Command transfer in progress interrupt
+ *            @arg SDIO_IT_TXACT:    Data transmit in progress interrupt
+ *            @arg SDIO_IT_RXACT:    Data receive in progress interrupt
+ *            @arg SDIO_IT_TXFIFOHE: Transmit FIFO Half Empty interrupt
+ *            @arg SDIO_IT_RXFIFOHF: Receive FIFO Half Full interrupt
+ *            @arg SDIO_IT_TXFIFOF:  Transmit FIFO full interrupt
+ *            @arg SDIO_IT_RXFIFOF:  Receive FIFO full interrupt
+ *            @arg SDIO_IT_TXFIFOE:  Transmit FIFO empty interrupt
+ *            @arg SDIO_IT_RXFIFOE:  Receive FIFO empty interrupt
+ *            @arg SDIO_IT_TXDAVL:   Data available in transmit FIFO interrupt
+ *            @arg SDIO_IT_RXDAVL:   Data available in receive FIFO interrupt
+ *            @arg SDIO_IT_SDIOIT:   SD I/O interrupt received interrupt
+ *            @arg SDIO_IT_CEATAEND: CE-ATA command completion signal received for CMD61 interrupt
+ * @retval The new state of SDIO_IT (SET or RESET).
+ */
+    #define __SDIO_GET_IT    ( __INSTANCE__, __INTERRUPT__ )( ( ( __INSTANCE__ )->STA & ( __INTERRUPT__ ) ) == ( __INTERRUPT__ ) )
+
+/**
+ * @brief  Clears the SDIO's interrupt pending bits.
+ * @param  __INSTANCE__ : Pointer to SDIO register base
+ * @param  __INTERRUPT__: specifies the interrupt pending bit to clear.
+ *          This parameter can be one or a combination of the following values:
+ *            @arg SDIO_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
+ *            @arg SDIO_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
+ *            @arg SDIO_IT_CTIMEOUT: Command response timeout interrupt
+ *            @arg SDIO_IT_DTIMEOUT: Data timeout interrupt
+ *            @arg SDIO_IT_TXUNDERR: Transmit FIFO underrun error interrupt
+ *            @arg SDIO_IT_RXOVERR:  Received FIFO overrun error interrupt
+ *            @arg SDIO_IT_CMDREND:  Command response received (CRC check passed) interrupt
+ *            @arg SDIO_IT_CMDSENT:  Command sent (no response required) interrupt
+ *            @arg SDIO_IT_DATAEND:  Data end (data counter, SDIO_DCOUNT, is zero) interrupt
+ *            @arg SDIO_IT_STBITERR: Start bit not detected on all data signals in wide
+ *                                   bus mode interrupt
+ *            @arg SDIO_IT_SDIOIT:   SD I/O interrupt received interrupt
+ *            @arg SDIO_IT_CEATAEND: CE-ATA command completion signal received for CMD61
+ * @retval None
+ */
+    #define __SDIO_CLEAR_IT( __INSTANCE__, __INTERRUPT__ )    ( ( __INSTANCE__ )->ICR = ( __INTERRUPT__ ) )
+
+/**
+ * @brief  Enable Start the SD I/O Read Wait operation.
+ * @retval None
+ */
+    #define __SDIO_START_READWAIT_ENABLE()                    ( *( __IO uint32_t * ) DCTRL_RWSTART_BB = ENABLE )
+
+/**
+ * @brief  Disable Start the SD I/O Read Wait operations.
+ * @retval None
+ */
+    #define __SDIO_START_READWAIT_DISABLE()                   ( *( __IO uint32_t * ) DCTRL_RWSTART_BB = DISABLE )
+
+/**
+ * @brief  Enable Start the SD I/O Read Wait operation.
+ * @retval None
+ */
+    #define __SDIO_STOP_READWAIT_ENABLE()                     ( *( __IO uint32_t * ) DCTRL_RWSTOP_BB = ENABLE )
+
+/**
+ * @brief  Disable Stop the SD I/O Read Wait operations.
+ * @retval None
+ */
+    #define __SDIO_STOP_READWAIT_DISABLE()                    ( *( __IO uint32_t * ) DCTRL_RWSTOP_BB = DISABLE )
+
+/**
+ * @brief  Enable the SD I/O Mode Operation.
+ * @retval None
+ */
+    #define __SDIO_OPERATION_ENABLE()                         ( *( __IO uint32_t * ) DCTRL_SDIOEN_BB = ENABLE )
+
+/**
+ * @brief  Disable the SD I/O Mode Operation.
+ * @retval None
+ */
+    #define __SDIO_OPERATION_DISABLE()                        ( *( __IO uint32_t * ) DCTRL_SDIOEN_BB = DISABLE )
+
+/**
+ * @brief  Enable the SD I/O Suspend command sending.
+ * @retval None
+ */
+    #define __SDIO_SUSPEND_CMD_ENABLE()                       ( *( __IO uint32_t * ) CMD_SDIOSUSPEND_BB = ENABLE )
+
+/**
+ * @brief  Disable the SD I/O Suspend command sending.
+ * @retval None
+ */
+    #define __SDIO_SUSPEND_CMD_DISABLE()                      ( *( __IO uint32_t * ) CMD_SDIOSUSPEND_BB = DISABLE )
+
+/**
+ * @brief  Enable the command completion signal.
+ * @retval None
+ */
+    #define __SDIO_CEATA_CMD_COMPLETION_ENABLE()              ( *( __IO uint32_t * ) CMD_ENCMDCOMPL_BB = ENABLE )
+
+/**
+ * @brief  Disable the command completion signal.
+ * @retval None
+ */
+    #define __SDIO_CEATA_CMD_COMPLETION_DISABLE()             ( *( __IO uint32_t * ) CMD_ENCMDCOMPL_BB = DISABLE )
+
+/**
+ * @brief  Enable the CE-ATA interrupt.
+ * @retval None
+ */
+    #define __SDIO_CEATA_ENABLE_IT()                          ( *( __IO uint32_t * ) CMD_NIEN_BB = ( uint32_t ) 0 )
+
+/**
+ * @brief  Disable the CE-ATA interrupt.
+ * @retval None
+ */
+    #define __SDIO_CEATA_DISABLE_IT()                         ( *( __IO uint32_t * ) CMD_NIEN_BB = ( uint32_t ) 1 )
+
+/**
+ * @brief  Enable send CE-ATA command (CMD61).
+ * @retval None
+ */
+    #define __SDIO_CEATA_SENDCMD_ENABLE()                     ( *( __IO uint32_t * ) CMD_ATACMD_BB = ENABLE )
+
+/**
+ * @brief  Disable send CE-ATA command (CMD61).
+ * @retval None
+ */
+    #define __SDIO_CEATA_SENDCMD_DISABLE()                    ( *( __IO uint32_t * ) CMD_ATACMD_BB = DISABLE )
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @addtogroup SDMMC_LL_Exported_Functions
+ * @{
+ */
+
+/* Initialization/de-initialization functions  **********************************/
+
+/** @addtogroup HAL_SDMMC_LL_Group1
+ * @{
+ */
+    HAL_StatusTypeDef SDIO_Init( SDIO_TypeDef * SDIOx,
+                                 SDIO_InitTypeDef Init );
+
+/**
+ * @}
+ */
+
+/* I/O operation functions  *****************************************************/
+
+/** @addtogroup HAL_SDMMC_LL_Group2
+ * @{
+ */
+/* Blocking mode: Polling */
+    uint32_t SDIO_ReadFIFO( SDIO_TypeDef * SDIOx );
+    HAL_StatusTypeDef SDIO_WriteFIFO( SDIO_TypeDef * SDIOx,
+                                      uint32_t * pWriteData );
+
+/**
+ * @}
+ */
+
+/* Peripheral Control functions  ************************************************/
+
+/** @addtogroup HAL_SDMMC_LL_Group3
+ * @{
+ */
+    HAL_StatusTypeDef SDIO_PowerState_ON( SDIO_TypeDef * SDIOx );
+    HAL_StatusTypeDef SDIO_PowerState_OFF( SDIO_TypeDef * SDIOx );
+    uint32_t SDIO_GetPowerState( SDIO_TypeDef * SDIOx );
+
+/* Command path state machine (CPSM) management functions */
+    HAL_StatusTypeDef SDIO_SendCommand( SDIO_TypeDef * SDIOx,
+                                        SDIO_CmdInitTypeDef * SDIO_CmdInitStruct );
+    uint8_t SDIO_GetCommandResponse( SDIO_TypeDef * SDIOx );
+    uint32_t SDIO_GetResponse( uint32_t SDIO_RESP );
+
+/* Data path state machine (DPSM) management functions */
+    HAL_StatusTypeDef SDIO_DataConfig( SDIO_TypeDef * SDIOx,
+                                       SDIO_DataInitTypeDef * SDIO_DataInitStruct );
+    uint32_t SDIO_GetDataCounter( SDIO_TypeDef * SDIOx );
+    uint32_t SDIO_GetFIFOCount( SDIO_TypeDef * SDIOx );
+
+/* SDIO IO Cards mode management functions */
+    HAL_StatusTypeDef SDIO_SetSDIOReadWaitMode( uint32_t SDIO_ReadWaitMode );
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+    #ifdef __cplusplus
+        }
+    #endif
+
+#endif /* __STM32F4xx_LL_SDMMC_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
This PR adds the low-layer HAL module `stm32f4xx_ll_sdmmc.c`.
It is created and distributed by ST-Electronics.
It has evaluated through time, and there are many different versions around. I just found 6 versions on my disk, not 2 are equal

This version fits well with [the other sources](https://github.com/FreeRTOS/Lab-Project-FreeRTOS-FAT/tree/master/portable/STM32F4xx). I have always used it while developing and testing FreeRTOS+FAT.
