### PR TITLE
Call memcpy to copy a struct

### DIFF
--- a/ff_stdio.c
+++ b/ff_stdio.c
@@ -1496,7 +1496,7 @@ int ff_findnext( FF_FindData_t * pxFindData )
                     /* Date of Last Access. */
                     memcpy( &( pxFindData->xDirectoryEntry.xAccessedTime ),
                             &( pxFindData->xDirectoryEntry.xCreateTime ),
-                            sizeof pxFindData->xDirectoryEntry.xAccessedTime );
+                            sizeof( pxFindData->xDirectoryEntry.xAccessedTime ) );
                 }
             }
         #endif /* ffconfigTIME_SUPPORT */

--- a/ff_stdio.c
+++ b/ff_stdio.c
@@ -1492,7 +1492,7 @@ int ff_findnext( FF_FindData_t * pxFindData )
                     /* Date and Time Modified. */
                     memcpy( &( pxFindData->xDirectoryEntry.xModifiedTime ),
                             &( pxFindData->xDirectoryEntry.xCreateTime ),
-                            sizeof pxFindData->xDirectoryEntry.xModifiedTime );
+                            sizeof( pxFindData->xDirectoryEntry.xModifiedTime ) );
                     /* Date of Last Access. */
                     memcpy( &( pxFindData->xDirectoryEntry.xAccessedTime ),
                             &( pxFindData->xDirectoryEntry.xCreateTime ),

--- a/ff_stdio.c
+++ b/ff_stdio.c
@@ -1489,8 +1489,14 @@ int ff_findnext( FF_FindData_t * pxFindData )
                     pxFindData->xDirectoryEntry.xCreateTime.Hour = ( uint16_t ) xTimeStruct.tm_hour;            /* Hour (0 - 23). */
                     pxFindData->xDirectoryEntry.xCreateTime.Minute = ( uint16_t ) xTimeStruct.tm_min;           /* Min (0 - 59). */
                     pxFindData->xDirectoryEntry.xCreateTime.Second = ( uint16_t ) xTimeStruct.tm_sec;           /* Second (0 - 59). */
-                    pxFindData->xDirectoryEntry.xModifiedTime = pxFindData->xDirectoryEntry.xCreateTime;        /* Date and Time Modified. */
-                    pxFindData->xDirectoryEntry.xAccessedTime = pxFindData->xDirectoryEntry.xCreateTime;        /* Date of Last Access. */
+                    /* Date and Time Modified. */
+                    memcpy( &( pxFindData->xDirectoryEntry.xModifiedTime ),
+                            &( pxFindData->xDirectoryEntry.xCreateTime ),
+                            sizeof pxFindData->xDirectoryEntry.xModifiedTime );
+                    /* Date of Last Access. */
+                    memcpy( &( pxFindData->xDirectoryEntry.xAccessedTime ),
+                            &( pxFindData->xDirectoryEntry.xCreateTime ),
+                            sizeof pxFindData->xDirectoryEntry.xAccessedTime );
                 }
             }
         #endif /* ffconfigTIME_SUPPORT */

--- a/include/ff_dir.h
+++ b/include/ff_dir.h
@@ -64,6 +64,8 @@ typedef struct
     uint32_t ulAddrCurrentCluster;
     uint32_t ulDirCluster;
     uint16_t usCurrentItem;
+    /* Sill uip two bytes to make the next struct 32-bit aligned. */
+    uint16_t usFillerBytes;
     /* End Book Keeping. */
 
     #if ( ffconfigTIME_SUPPORT != 0 )

--- a/include/ff_dir.h
+++ b/include/ff_dir.h
@@ -64,7 +64,7 @@ typedef struct
     uint32_t ulAddrCurrentCluster;
     uint32_t ulDirCluster;
     uint16_t usCurrentItem;
-    /* Sill uip two bytes to make the next struct 32-bit aligned. */
+    /* Insert 2 bytes to make the next struct 32-bit aligned. */
     uint16_t usFillerBytes;
     /* End Book Keeping. */
 


### PR DESCRIPTION
I have never trusted compilers when copying a struct in an assignment:
~~~
	struct xStruct { int a, b, c; };
	xStruct s1, s2;
	s1 = s2;
~~~

In [one occasion](https://github.com/FreeRTOS/Lab-Project-FreeRTOS-FAT/blob/5760fc95ab0f7a7d86f4fcf16b8e9ab5b7aec03a/ff_stdio.c#L1492) in FreeRTOS+FAT, there is such an assignment:
~~~diff
-    pxFindData->xDirectoryEntry.xModifiedTime = pxFindData->xDirectoryEntry.xCreateTime;        /* Date and Time Modified. */
+    /* Date and Time Modified. */
+    memcpy( &( pxFindData->xDirectoryEntry.xModifiedTime ),
+            &( pxFindData->xDirectoryEntry.xCreateTime ),
+            sizeof pxFindData->xDirectoryEntry.xModifiedTime );
-    pxFindData->xDirectoryEntry.xAccessedTime = pxFindData->xDirectoryEntry.xCreateTime;        /* Date of Last Access. */
+    /* Date of Last Access. */
+    memcpy( &( pxFindData->xDirectoryEntry.xAccessedTime ),
+            &( pxFindData->xDirectoryEntry.xCreateTime ),
+            sizeof pxFindData->xDirectoryEntry.xAccessedTime );
~~~
The above change helps avoiding a fatal exception. I've never seen this crashing before. I am compiling it for a STM32F7xx.
