### PR TITLE
Protect ff_open with special semaphore

### DIFF
--- a/ff_dir.c
+++ b/ff_dir.c
@@ -1722,11 +1722,8 @@ FF_Error_t FF_PopulateLongDirent( FF_IOManager_t * pxIOManager,
                     if( pxDirEntry->ulDirCluster != 0 )
                     {
                         /* Valid Dir found, copy the wildCard to filename! */
-                        #if ( ffconfigUNICODE_UTF16_SUPPORT != 0 )
-                            wcsncpy( pxDirEntry->pcWildCard, ++pcWildCard, ffconfigMAX_FILENAME );
-                        #else
-                            strncpy( pxDirEntry->pcWildCard, ++pcWildCard, ffconfigMAX_FILENAME );
-                        #endif
+                        STRNCPY( pxDirEntry->pcWildCard, ++pcWildCard, ffconfigMAX_FILENAME - 1 );
+                        pxDirEntry->pcWildCard[ ffconfigMAX_FILENAME - 1 ] = 0;
 
                         if( pxDirEntry->pcWildCard[ xIndex - 1 ] == ':' )
                         {
@@ -2658,7 +2655,8 @@ int32_t FF_FindShortName( FF_IOManager_t * pxIOManager,
                         }
                         else
                         {
-                            wcsncpy( usUtf16Name, pcName, ffconfigMAX_FILENAME );
+                            wcsncpy( usUtf16Name, pcName, ffconfigMAX_FILENAME - 1 );
+                            usUtf16Name[ ffconfigMAX_FILENAME - 1 ] = 0;
                         }
                     }
                 #else /* if WCHAR_MAX <= 0xFFFF */
@@ -3125,15 +3123,8 @@ FF_Error_t FF_CreateDirent( FF_IOManager_t * pxIOManager,
 
     memset( &xMyFile, '\0', sizeof( xMyFile ) );
 
-    #if ( ffconfigUNICODE_UTF16_SUPPORT != 0 )
-        {
-            wcsncpy( xMyFile.pcFileName, pcFileName, ffconfigMAX_FILENAME );
-        }
-    #else
-        {
-            strncpy( xMyFile.pcFileName, pcFileName, ffconfigMAX_FILENAME );
-        }
-    #endif
+    STRNCPY( xMyFile.pcFileName, pcFileName, ffconfigMAX_FILENAME  - 1 );
+    xMyFile.pcFileName[ ffconfigMAX_FILENAME - 1 ] = 0;
 
     xMyFile.ulObjectCluster = FF_CreateClusterChain( pxIOManager, &xError );
 
@@ -3308,15 +3299,8 @@ FF_Error_t FF_CreateDirent( FF_IOManager_t * pxIOManager,
             break;
         }
 
-        #if ( ffconfigUNICODE_UTF16_SUPPORT != 0 )
-            {
-                wcsncpy( xMyDirectory.pcFileName, pcDirName, ffconfigMAX_FILENAME );
-            }
-        #else
-            {
-                strncpy( xMyDirectory.pcFileName, pcDirName, ffconfigMAX_FILENAME );
-            }
-        #endif
+        STRNCPY( xMyDirectory.pcFileName, pcDirName, ffconfigMAX_FILENAME - 1 );
+        xMyDirectory.pcFileName[ ffconfigMAX_FILENAME - 1 ] = 0;
 
         xMyDirectory.ulFileSize = 0;
         xMyDirectory.ucAttrib = FF_FAT_ATTR_DIR;

--- a/ff_file.c
+++ b/ff_file.c
@@ -243,6 +243,15 @@ static FF_FILE * prvAllocFileHandle( FF_IOManager_t * pxIOManager,
         char pcFileName[ ffconfigMAX_FILENAME ];
     #endif
 
+    #if ( ffconfigPROTECT_FF_FOPEN_WITH_SEMAPHORE == 1 )
+        {
+            if( ( ucMode & FF_MODE_CREATE ) != 0U )
+            {
+                FF_PendSemaphore( pxIOManager->pvSemaphoreOpen );
+            }
+        }
+    #endif
+
     memset( &xFindParams, '\0', sizeof( xFindParams ) );
 
     /* Inform the functions that the entry will be created if not found. */
@@ -462,6 +471,15 @@ static FF_FILE * prvAllocFileHandle( FF_IOManager_t * pxIOManager,
 
         pxFile = NULL;
     }
+
+    #if ( ffconfigPROTECT_FF_FOPEN_WITH_SEMAPHORE == 1 )
+        {
+            if( ( ucMode & FF_MODE_CREATE ) != 0U )
+            {
+                FF_ReleaseSemaphore( pxIOManager->pvSemaphoreOpen );
+            }
+        }
+    #endif
 
     if( pxError != NULL )
     {

--- a/ff_file.c
+++ b/ff_file.c
@@ -292,7 +292,8 @@ static FF_FILE * prvAllocFileHandle( FF_IOManager_t * pxIOManager,
         }
 
         /* Copy the file name, i.e. the string that comes after the last separator. */
-        STRNCPY( pcFileName, pcPath + xIndex + 1, ffconfigMAX_FILENAME );
+        STRNCPY( pcFileName, pcPath + xIndex + 1, ffconfigMAX_FILENAME - 1 );
+        pcFileName[ ffconfigMAX_FILENAME - 1 ] = 0;
 
         if( xIndex == 0 )
         {
@@ -975,7 +976,8 @@ static FF_FILE * prvAllocFileHandle( FF_IOManager_t * pxIOManager,
                     }
 
                     /* Copy the base name of the destination file. */
-                    STRNCPY( xMyFile.pcFileName, ( szDestinationFile + xIndex + 1 ), ffconfigMAX_FILENAME );
+                    STRNCPY( xMyFile.pcFileName, ( szDestinationFile + xIndex + 1 ), ffconfigMAX_FILENAME - 1 );
+                    xMyFile.pcFileName[ ffconfigMAX_FILENAME - 1 ] = 0;
 
                     if( xIndex == 0 )
                     {
@@ -2871,7 +2873,8 @@ FF_Error_t FF_CheckValid( FF_FILE * pxFile )
             xIndex--;
         }
 
-        STRNCPY( pcFileName, ( pcPath + xIndex + 1 ), ffconfigMAX_FILENAME );
+        STRNCPY( pcFileName, ( pcPath + xIndex + 1 ), ffconfigMAX_FILENAME - 1 );
+        pcFileName[ ffconfigMAX_FILENAME - 1 ] = 0;
 
         if( xIndex == 0 )
         {
@@ -2968,7 +2971,8 @@ FF_Error_t FF_CheckValid( FF_FILE * pxFile )
         xIndex--;
     }
 
-    STRNCPY( pcFileName, ( pcPath + xIndex + 1 ), ffconfigMAX_FILENAME );
+    STRNCPY( pcFileName, ( pcPath + xIndex + 1 ), ffconfigMAX_FILENAME - 1 );
+    pcFileName[ ffconfigMAX_FILENAME - 1 ] = 0;
 
     if( xIndex == 0 )
     {

--- a/ff_ioman.c
+++ b/ff_ioman.c
@@ -662,7 +662,7 @@ int32_t FF_BlockWrite( FF_IOManager_t * pxIOManager,
     if( ( slRetVal == 0ul ) && ( pxIOManager->xBlkDevice.fnpWriteBlocks != NULL ) )
     {
         do
-        { /* Make sure we don't execute a NULL. */
+        {   /* Make sure we don't execute a NULL. */
             if( ( xSemLocked == pdFALSE ) &&
                 ( ( pxIOManager->ucFlags & FF_IOMAN_BLOCK_DEVICE_IS_REENTRANT ) == pdFALSE ) )
             {
@@ -1518,7 +1518,7 @@ FF_Error_t FF_Mount( FF_Disk_t * pxDisk,
         }
 
         if( pxPartition->ulSectorsPerFAT == 0 )
-        { /* FAT32 */
+        {   /* FAT32 */
             pxPartition->ulSectorsPerFAT = FF_getLong( pxBuffer->pucBuffer, FF_FAT_32_SECTORS_PER_FAT );
             pxPartition->ulRootDirCluster = FF_getLong( pxBuffer->pucBuffer, FF_FAT_ROOT_DIR_CLUSTER );
             memcpy( pxPartition->pcVolumeLabel, pxBuffer->pucBuffer + FF_FAT_32_VOL_LABEL, sizeof( pxPartition->pcVolumeLabel ) - 1 );
@@ -1530,7 +1530,7 @@ FF_Error_t FF_Mount( FF_Disk_t * pxDisk,
         }
 
         pxPartition->ulClusterBeginLBA = pxPartition->ulFATBeginLBA + ( pxPartition->ucNumFATS * pxPartition->ulSectorsPerFAT );
-        #if ( ffconfigWRITE_FREE_COUNT != 0 )
+        #if ( ffconfigWRITE_FREE_COUNT != 0 ) || ( ffconfigFSINFO_TRUSTED != 0 )
             {
                 pxPartition->ulFSInfoLBA = pxPartition->ulBeginLBA + FF_getShort( pxBuffer->pucBuffer, 48 );
             }

--- a/ff_sys.c
+++ b/ff_sys.c
@@ -141,7 +141,8 @@ int FF_FS_Add( const char * pcPath,
             if( xUseIndex >= ( BaseType_t ) 0 )
             {
                 iReturn = pdTRUE;
-                strncpy( file_systems.xSystems[ xUseIndex ].pcPath, pcPath, sizeof( file_systems.xSystems[ xUseIndex ].pcPath ) );
+                strncpy( file_systems.xSystems[ xUseIndex ].pcPath, pcPath, sizeof( file_systems.xSystems[ xUseIndex ].pcPath ) - 1 );
+                file_systems.xSystems[ xUseIndex ].pcPath[ sizeof( file_systems.xSystems[ xUseIndex ].pcPath ) - 1 ] = 0;
                 file_systems.xSystems[ xUseIndex ].xPathlen = uxPathLength;
                 file_systems.xSystems[ xUseIndex ].pxManager = pxDisk->pxIOManager;
             }

--- a/include/FreeRTOSFATConfigDefaults.h
+++ b/include/FreeRTOSFATConfigDefaults.h
@@ -122,7 +122,7 @@
  * - UTF-8  (ffconfigUNICODE_UTF8_SUPPORT = 1)
  * - UTF-16 (ffconfigUNICODE_UTF16_SUPPORT = 1)
  */
-#if ( ffconfigUNICODE_UTF16_SUPPORT == 0 )
+#if !defined( ffconfigUNICODE_UTF16_SUPPORT )
 
 /* Only used when ffconfigLFN_SUPPORT is set to 1.
  *
@@ -436,7 +436,8 @@
 /* Sets the maximum length for file names, including the path.
  * Note that the value of this define is directly related to the maximum stack
  * use of the +FAT library. In some API's, a character buffer of size
- * 'ffconfigMAX_FILENAME' will be declared on stack. */
+ * 'ffconfigMAX_FILENAME' will be declared on stack. As such, this value should
+ * include space for the null byte. */
     #define ffconfigMAX_FILENAME    129
 #endif
 
@@ -465,11 +466,10 @@
 #endif
 
 #ifndef ffconfigFAT_USES_STAT
-
-/* When enabled, the library keeps statistics about the use of cache
- * buffers.  This can be useful while configuring or optimising the
- * cache size. */
-    #define ffconfigFAT_USES_STAT    0
+    /* When enabled, the library keeps statistics about the use of cache
+	 * buffers.  This can be useful while configuring or optimising the
+	 * cache size. */
+	#define ffconfigFAT_USES_STAT     0
 #endif
 
 #ifndef ffconfigUSE_NOTIFY
@@ -505,19 +505,9 @@
     #define ffconfigNOT_USED_FOR_NOW    0
 #endif
 
-
-#ifndef ffconfigPROTECT_FF_FOPEN_WITH_SEMAPHORE
-
-/* When FF_Open() is called to create a file, protect the entire function
- * with a dedicated semaphore called FF_IOManager_t::pvSemaphoreOpen.
- * As the race condition occurs rarely, it will be disabled.
- */
-    #define ffconfigPROTECT_FF_FOPEN_WITH_SEMAPHORE    0
-#endif
-
 #ifndef FF_NOSTRCASECMP
-    /* When zero, the function 'strcasecmp()' will be dfined. */
-    #define FF_NOSTRCASECMP    0
+	/* When zero, the function 'strcasecmp()' will be dfined. */
+	#define FF_NOSTRCASECMP    0
 #endif
 
 #endif /* ifndef FF_DEFAULTCONFIG_H */

--- a/include/FreeRTOSFATConfigDefaults.h
+++ b/include/FreeRTOSFATConfigDefaults.h
@@ -465,10 +465,11 @@
 #endif
 
 #ifndef ffconfigFAT_USES_STAT
-    /* When enabled, the library keeps statistics about the use of cache
-	 * buffers.  This can be useful while configuring or optimising the
-	 * cache size. */
-	#define ffconfigFAT_USES_STAT     0
+
+/* When enabled, the library keeps statistics about the use of cache
+ * buffers.  This can be useful while configuring or optimising the
+ * cache size. */
+    #define ffconfigFAT_USES_STAT    0
 #endif
 
 #ifndef ffconfigUSE_NOTIFY
@@ -504,9 +505,19 @@
     #define ffconfigNOT_USED_FOR_NOW    0
 #endif
 
+
+#ifndef ffconfigPROTECT_FF_FOPEN_WITH_SEMAPHORE
+
+/* When FF_Open() is called to create a file, protect the entire function
+ * with a dedicated semaphore called FF_IOManager_t::pvSemaphoreOpen.
+ * As the race condition occurs rarely, it will be disabled.
+ */
+    #define ffconfigPROTECT_FF_FOPEN_WITH_SEMAPHORE    0
+#endif
+
 #ifndef FF_NOSTRCASECMP
-	/* When zero, the function 'strcasecmp()' will be dfined. */
-	#define FF_NOSTRCASECMP    0
+    /* When zero, the function 'strcasecmp()' will be dfined. */
+    #define FF_NOSTRCASECMP    0
 #endif
 
 #endif /* ifndef FF_DEFAULTCONFIG_H */

--- a/include/ff_dir.h
+++ b/include/ff_dir.h
@@ -64,6 +64,8 @@ typedef struct
     uint32_t ulAddrCurrentCluster;
     uint32_t ulDirCluster;
     uint16_t usCurrentItem;
+    /* Insert 2 bytes to make the next struct 32-bit aligned. */
+    uint16_t usFillerBytes;
     /* End Book Keeping. */
 
     #if ( ffconfigTIME_SUPPORT != 0 )

--- a/include/ff_ioman.h
+++ b/include/ff_ioman.h
@@ -238,7 +238,7 @@
         uint32_t ulSectorsPerFAT; /* Number of sectors per Fat. */
         uint32_t ulTotalSectors;
         uint32_t ulDataSectors;
-        #if ( ffconfigWRITE_FREE_COUNT != 0 )
+        #if ( ffconfigWRITE_FREE_COUNT != 0 ) || ( ffconfigFSINFO_TRUSTED != 0 )
             uint32_t ulFSInfoLBA; /* LBA of the FSINFO sector. */
         #endif
         uint32_t ulRootDirSectors;

--- a/include/ff_ioman.h
+++ b/include/ff_ioman.h
@@ -289,6 +289,9 @@
         FF_Partition_t xPartition;   /* A partition description. */
         FF_Buffer_t * pxBuffers;     /* Pointer to an array of buffer descriptors. */
         void * pvSemaphore;          /* Pointer to a Semaphore object. (For buffer description modifications only!). */
+        #if ( ffconfigPROTECT_FF_FOPEN_WITH_SEMAPHORE == 1 )
+            void * pvSemaphoreOpen;  /* A semaphore to protect FF_Open() against race conditions. */
+        #endif
         void * FirstFile;            /* Pointer to the first File object. */
         void * xEventGroup;          /* An event group, used for locking FAT, DIR and Buffers. Replaces ucLocks. */
         uint8_t * pucCacheMem;       /* Pointer to a block of memory for the cache. */

--- a/portable/Zynq.2019.3/ff_sddisk.c
+++ b/portable/Zynq.2019.3/ff_sddisk.c
@@ -407,7 +407,7 @@ static CacheMemoryInfo_t * pucGetSDIOCacheMemory( BaseType_t xPartition )
 
     if( ( xPartition < 0 ) || ( xPartition >= ffconfigMAX_PARTITIONS ) )
     {
-        FF_PRINTF( "pucGetSDIOCacheMemory: bad partition number: %d ( max %d )\n", (int)xPartition, ffconfigMAX_PARTITIONS - 1 );
+        FF_PRINTF( "pucGetSDIOCacheMemory: bad partition number: %d ( max %d )\n", ( int ) xPartition, ffconfigMAX_PARTITIONS - 1 );
         xReturn = NULL;
     }
     else if( pxCacheMemories[ xPartition ] == NULL )
@@ -964,8 +964,8 @@ volatile unsigned sd_int_count = 0;
         {
             if( ( ulSDInterruptStatus[ iIndex ] & ulSDExpectedStatus[ iIndex ] ) == ulSDExpectedStatus[ iIndex ] )
             {
-            BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-            xSemaphoreGiveFromISR( xSDSemaphores[ iIndex ], &xHigherPriorityTaskWoken );
+                BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+                xSemaphoreGiveFromISR( xSDSemaphores[ iIndex ], &xHigherPriorityTaskWoken );
                 portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
             }
         }
@@ -1062,7 +1062,7 @@ volatile unsigned sd_int_count = 0;
         if( ( ulStatusReg & ulBitMask ) != ulBitMask )
         {
             ulStatusReg = XSdPs_ReadReg( InstancePtr->Config.BaseAddress, XSDPS_NORM_INTR_STS_OFFSET );
-            FF_PRINTF( "%s: XSdPs_WaitInterrupt = 0x%02x\r\n", __func__, (unsigned)ulStatusReg );
+            FF_PRINTF( "%s: XSdPs_WaitInterrupt = 0x%02x\r\n", __func__, ( unsigned ) ulStatusReg );
 
             /* Avoid logging about the 'CMD1' command which always fails on an SD-card. */
             if( ulWait != 0U )

--- a/portable/Zynq.2019.3/ff_sddisk.c
+++ b/portable/Zynq.2019.3/ff_sddisk.c
@@ -407,7 +407,7 @@ static CacheMemoryInfo_t * pucGetSDIOCacheMemory( BaseType_t xPartition )
 
     if( ( xPartition < 0 ) || ( xPartition >= ffconfigMAX_PARTITIONS ) )
     {
-        FF_PRINTF( "pucGetSDIOCacheMemory: bad partition number: %d ( max %d )\n", ( int ) xPartition, ffconfigMAX_PARTITIONS - 1 );
+        FF_PRINTF( "pucGetSDIOCacheMemory: bad partition number: %d ( max %d )\n", (int)xPartition, ffconfigMAX_PARTITIONS - 1 );
         xReturn = NULL;
     }
     else if( pxCacheMemories[ xPartition ] == NULL )
@@ -1062,7 +1062,7 @@ volatile unsigned sd_int_count = 0;
         if( ( ulStatusReg & ulBitMask ) != ulBitMask )
         {
             ulStatusReg = XSdPs_ReadReg( InstancePtr->Config.BaseAddress, XSDPS_NORM_INTR_STS_OFFSET );
-            FF_PRINTF( "%s: XSdPs_WaitInterrupt = 0x%02x\r\n", __func__, ( unsigned ) ulStatusReg );
+            FF_PRINTF( "%s: XSdPs_WaitInterrupt = 0x%02x\r\n", __func__, (unsigned)ulStatusReg );
 
             /* Avoid logging about the 'CMD1' command which always fails on an SD-card. */
             if( ulWait != 0U )

--- a/portable/Zynq.2019.3/xsdps.c
+++ b/portable/Zynq.2019.3/xsdps.c
@@ -468,7 +468,7 @@ s32 XSdPs_SdCardInitialize( XSdPs * InstancePtr )
         goto RETURN_PATH;
     }
 
-    FF_PRINTF( "CMD0 : %d\n", (int)Status );
+    FF_PRINTF( "CMD0 : %d\n", ( int ) Status );
 
     /*
      * CMD8; response expected
@@ -476,7 +476,7 @@ s32 XSdPs_SdCardInitialize( XSdPs * InstancePtr )
      */
     Status = XSdPs_CmdTransfer( InstancePtr, CMD8,
                                 XSDPS_CMD8_VOL_PATTERN, 0U );
-    FF_PRINTF( "CMD8 : %d\n", (int)Status );
+    FF_PRINTF( "CMD8 : %d\n", ( int ) Status );
 
     if( ( Status != XST_SUCCESS ) && ( Status != XSDPS_CT_ERROR ) )
     {
@@ -656,35 +656,35 @@ s32 XSdPs_SdCardInitialize( XSdPs * InstancePtr )
         mmc_decode_cid( &myCSD, &myCID, resp );
     }
 
-        CSD[ 0 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
-                                  XSDPS_RESP0_OFFSET );
-        CSD[ 1 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
-                                  XSDPS_RESP1_OFFSET );
-        CSD[ 2 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
-                                  XSDPS_RESP2_OFFSET );
-        CSD[ 3 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
-                                  XSDPS_RESP3_OFFSET );
+    CSD[ 0 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
+                              XSDPS_RESP0_OFFSET );
+    CSD[ 1 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
+                              XSDPS_RESP1_OFFSET );
+    CSD[ 2 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
+                              XSDPS_RESP2_OFFSET );
+    CSD[ 3 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
+                              XSDPS_RESP3_OFFSET );
 
-        if( ( ( CSD[ 3 ] & CSD_STRUCT_MASK ) >> 22U ) == 0U )
-        {
-            BlkLen = 1U << ( ( u32 ) ( CSD[ 2 ] & READ_BLK_LEN_MASK ) >> 8U );
-            Mult = 1U << ( ( u32 ) ( ( CSD[ 1 ] & C_SIZE_MULT_MASK ) >> 7U ) + 2U );
-            DeviceSize = ( CSD[ 1 ] & C_SIZE_LOWER_MASK ) >> 22U;
-            DeviceSize |= ( CSD[ 2 ] & C_SIZE_UPPER_MASK ) << 10U;
-            DeviceSize = ( DeviceSize + 1U ) * Mult;
-            DeviceSize = DeviceSize * BlkLen;
-            InstancePtr->SectorCount = ( DeviceSize / XSDPS_BLK_SIZE_512_MASK );
-        }
-        else if( ( ( CSD[ 3 ] & CSD_STRUCT_MASK ) >> 22U ) == 1U )
-        {
-            InstancePtr->SectorCount = ( ( ( CSD[ 1 ] & CSD_V2_C_SIZE_MASK ) >> 8U ) +
-                                         1U ) * 1024U;
-        }
-        else
-        {
-            Status = XST_FAILURE;
-            goto RETURN_PATH;
-        }
+    if( ( ( CSD[ 3 ] & CSD_STRUCT_MASK ) >> 22U ) == 0U )
+    {
+        BlkLen = 1U << ( ( u32 ) ( CSD[ 2 ] & READ_BLK_LEN_MASK ) >> 8U );
+        Mult = 1U << ( ( u32 ) ( ( CSD[ 1 ] & C_SIZE_MULT_MASK ) >> 7U ) + 2U );
+        DeviceSize = ( CSD[ 1 ] & C_SIZE_LOWER_MASK ) >> 22U;
+        DeviceSize |= ( CSD[ 2 ] & C_SIZE_UPPER_MASK ) << 10U;
+        DeviceSize = ( DeviceSize + 1U ) * Mult;
+        DeviceSize = DeviceSize * BlkLen;
+        InstancePtr->SectorCount = ( DeviceSize / XSDPS_BLK_SIZE_512_MASK );
+    }
+    else if( ( ( CSD[ 3 ] & CSD_STRUCT_MASK ) >> 22U ) == 1U )
+    {
+        InstancePtr->SectorCount = ( ( ( CSD[ 1 ] & CSD_V2_C_SIZE_MASK ) >> 8U ) +
+                                     1U ) * 1024U;
+    }
+    else
+    {
+        Status = XST_FAILURE;
+        goto RETURN_PATH;
+    }
 
     FF_PRINTF( "Sector count %u myCSD.capacity %u\n", ( unsigned ) InstancePtr->SectorCount, ( unsigned ) myCSD.capacity );
     Status = XST_SUCCESS;

--- a/portable/Zynq.2019.3/xsdps.c
+++ b/portable/Zynq.2019.3/xsdps.c
@@ -468,7 +468,7 @@ s32 XSdPs_SdCardInitialize( XSdPs * InstancePtr )
         goto RETURN_PATH;
     }
 
-    FF_PRINTF( "CMD0 : %d\n", ( int ) Status );
+    FF_PRINTF( "CMD0 : %d\n", (int)Status );
 
     /*
      * CMD8; response expected
@@ -476,7 +476,7 @@ s32 XSdPs_SdCardInitialize( XSdPs * InstancePtr )
      */
     Status = XSdPs_CmdTransfer( InstancePtr, CMD8,
                                 XSDPS_CMD8_VOL_PATTERN, 0U );
-    FF_PRINTF( "CMD8 : %d\n", ( int ) Status );
+    FF_PRINTF( "CMD8 : %d\n", (int)Status );
 
     if( ( Status != XST_SUCCESS ) && ( Status != XSDPS_CT_ERROR ) )
     {
@@ -656,35 +656,35 @@ s32 XSdPs_SdCardInitialize( XSdPs * InstancePtr )
         mmc_decode_cid( &myCSD, &myCID, resp );
     }
 
-    CSD[ 0 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
-                              XSDPS_RESP0_OFFSET );
-    CSD[ 1 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
-                              XSDPS_RESP1_OFFSET );
-    CSD[ 2 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
-                              XSDPS_RESP2_OFFSET );
-    CSD[ 3 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
-                              XSDPS_RESP3_OFFSET );
+	CSD[ 0 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
+							  XSDPS_RESP0_OFFSET );
+	CSD[ 1 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
+							  XSDPS_RESP1_OFFSET );
+	CSD[ 2 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
+							  XSDPS_RESP2_OFFSET );
+	CSD[ 3 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
+							  XSDPS_RESP3_OFFSET );
 
-    if( ( ( CSD[ 3 ] & CSD_STRUCT_MASK ) >> 22U ) == 0U )
-    {
-        BlkLen = 1U << ( ( u32 ) ( CSD[ 2 ] & READ_BLK_LEN_MASK ) >> 8U );
-        Mult = 1U << ( ( u32 ) ( ( CSD[ 1 ] & C_SIZE_MULT_MASK ) >> 7U ) + 2U );
-        DeviceSize = ( CSD[ 1 ] & C_SIZE_LOWER_MASK ) >> 22U;
-        DeviceSize |= ( CSD[ 2 ] & C_SIZE_UPPER_MASK ) << 10U;
-        DeviceSize = ( DeviceSize + 1U ) * Mult;
-        DeviceSize = DeviceSize * BlkLen;
-        InstancePtr->SectorCount = ( DeviceSize / XSDPS_BLK_SIZE_512_MASK );
-    }
-    else if( ( ( CSD[ 3 ] & CSD_STRUCT_MASK ) >> 22U ) == 1U )
-    {
-        InstancePtr->SectorCount = ( ( ( CSD[ 1 ] & CSD_V2_C_SIZE_MASK ) >> 8U ) +
-                                     1U ) * 1024U;
-    }
-    else
-    {
-        Status = XST_FAILURE;
-        goto RETURN_PATH;
-    }
+	if( ( ( CSD[ 3 ] & CSD_STRUCT_MASK ) >> 22U ) == 0U )
+	{
+		BlkLen = 1U << ( ( u32 ) ( CSD[ 2 ] & READ_BLK_LEN_MASK ) >> 8U );
+		Mult = 1U << ( ( u32 ) ( ( CSD[ 1 ] & C_SIZE_MULT_MASK ) >> 7U ) + 2U );
+		DeviceSize = ( CSD[ 1 ] & C_SIZE_LOWER_MASK ) >> 22U;
+		DeviceSize |= ( CSD[ 2 ] & C_SIZE_UPPER_MASK ) << 10U;
+		DeviceSize = ( DeviceSize + 1U ) * Mult;
+		DeviceSize = DeviceSize * BlkLen;
+		InstancePtr->SectorCount = ( DeviceSize / XSDPS_BLK_SIZE_512_MASK );
+	}
+	else if( ( ( CSD[ 3 ] & CSD_STRUCT_MASK ) >> 22U ) == 1U )
+	{
+		InstancePtr->SectorCount = ( ( ( CSD[ 1 ] & CSD_V2_C_SIZE_MASK ) >> 8U ) +
+									 1U ) * 1024U;
+	}
+	else
+	{
+		Status = XST_FAILURE;
+		goto RETURN_PATH;
+	}
 
     FF_PRINTF( "Sector count %u myCSD.capacity %u\n", ( unsigned ) InstancePtr->SectorCount, ( unsigned ) myCSD.capacity );
     Status = XST_SUCCESS;

--- a/portable/Zynq.2019.3/xsdps.h
+++ b/portable/Zynq.2019.3/xsdps.h
@@ -153,7 +153,6 @@
  *
  ******************************************************************************/
 
-
 #ifndef SDPS_H_
     #define SDPS_H_
 
@@ -304,9 +303,28 @@ void XSdPs_Idle( XSdPs * InstancePtr );
                                       u32 CardType );
     #endif /* if defined( ARMR5 ) || defined( __aarch64__ ) || defined( ARMA53_32 ) || defined( __MICROBLAZE__ ) */
 
+/* Make sure that the stored status is in ulSDInterruptStatus[] is cleared.
+ * ulMask are the status bits that should come high: either CC or CC|TC. */
+void XSdPs_ClearInterrupt( XSdPs * InstancePtr,
+                           uint32_t ulMask );
+
+/* Wait for an interrupt and return the 32 bits of the status register.
+ * A return value of 0 means: time-out. */
+u32 XSdPs_WaitInterrupt( XSdPs * InstancePtr,
+                         u32 ulMask,
+                         u32 ulWait );
+
+s32 XSdPs_Wait_For( XSdPs * InstancePtr,
+                    u32 Mask,
+                    u32 Wait );
+u32 XSdPs_ReadStatus( XSdPs * InstancePtr );
+
+u32 UNSTUFF_BITS( u32 * ulResponse,
+                  int iFirst,
+                  int iSize );
     #ifdef __cplusplus
     }
     #endif
 
-#endif /* SD_H_ */
+#endif /* SDPS_H_ */
 /** @} */

--- a/portable/Zynq.2019.3/xsdps_g.c
+++ b/portable/Zynq.2019.3/xsdps_g.c
@@ -56,11 +56,11 @@
  * The configuration table for devices
  */
 
-#define XPAR_XSDPS_0_BUS_WIDTH                0 /* XSDPS_4_BIT_WIDTH */
-#define XPAR_XSDPS_0_MIO_BANK                 0
-#define XPAR_XSDPS_0_HAS_EMIO                 0
+#define XPAR_XSDPS_0_BUS_WIDTH            0 /* XSDPS_4_BIT_WIDTH */
+#define XPAR_XSDPS_0_MIO_BANK             0
+#define XPAR_XSDPS_0_HAS_EMIO             0
 #ifndef XPAR_XSDPS_0_IS_CACHE_COHERENT
-    #define XPAR_XSDPS_0_IS_CACHE_COHERENT    1 /* 0 Tables are located in uncached memory */
+#define XPAR_XSDPS_0_IS_CACHE_COHERENT    1 /* 0 Tables are located in uncached memory */
 #endif
 
 XSdPs_Config XSdPs_ConfigTable[] =

--- a/portable/Zynq.2019.3/xsdps_g.c
+++ b/portable/Zynq.2019.3/xsdps_g.c
@@ -56,11 +56,11 @@
  * The configuration table for devices
  */
 
-#define XPAR_XSDPS_0_BUS_WIDTH            0 /* XSDPS_4_BIT_WIDTH */
-#define XPAR_XSDPS_0_MIO_BANK             0
-#define XPAR_XSDPS_0_HAS_EMIO             0
+#define XPAR_XSDPS_0_BUS_WIDTH                0 /* XSDPS_4_BIT_WIDTH */
+#define XPAR_XSDPS_0_MIO_BANK                 0
+#define XPAR_XSDPS_0_HAS_EMIO                 0
 #ifndef XPAR_XSDPS_0_IS_CACHE_COHERENT
-#define XPAR_XSDPS_0_IS_CACHE_COHERENT    1 /* 0 Tables are located in uncached memory */
+    #define XPAR_XSDPS_0_IS_CACHE_COHERENT    1 /* 0 Tables are located in uncached memory */
 #endif
 
 XSdPs_Config XSdPs_ConfigTable[] =

--- a/portable/Zynq.2019.3/xsdps_g.c
+++ b/portable/Zynq.2019.3/xsdps_g.c
@@ -59,7 +59,9 @@
 #define XPAR_XSDPS_0_BUS_WIDTH            0 /* XSDPS_4_BIT_WIDTH */
 #define XPAR_XSDPS_0_MIO_BANK             0
 #define XPAR_XSDPS_0_HAS_EMIO             0
+#ifndef XPAR_XSDPS_0_IS_CACHE_COHERENT
 #define XPAR_XSDPS_0_IS_CACHE_COHERENT    1 /* 0 Tables are located in uncached memory */
+#endif
 
 XSdPs_Config XSdPs_ConfigTable[] =
 {

--- a/portable/Zynq.2019.3/xsdps_hw.h
+++ b/portable/Zynq.2019.3/xsdps_hw.h
@@ -1213,9 +1213,9 @@
  *		u16 XSdPs_ReadReg(u32 BaseAddress. int RegOffset)
  *
  ******************************************************************************/
-#ifndef INLINE
-    #define INLINE    __inline
-#endif
+    #ifndef INLINE
+        #define INLINE    __inline
+    #endif
     static INLINE u16 XSdPs_ReadReg16( u32 BaseAddress,
                                        u8 RegOffset )
     {

--- a/portable/Zynq.2019.3/xsdps_hw.h
+++ b/portable/Zynq.2019.3/xsdps_hw.h
@@ -1213,9 +1213,9 @@
  *		u16 XSdPs_ReadReg(u32 BaseAddress. int RegOffset)
  *
  ******************************************************************************/
-    #ifndef INLINE
-        #define INLINE    __inline
-    #endif
+#ifndef INLINE
+    #define INLINE    __inline
+#endif
     static INLINE u16 XSdPs_ReadReg16( u32 BaseAddress,
                                        u8 RegOffset )
     {

--- a/portable/Zynq.2019.3/xsdps_hw.h
+++ b/portable/Zynq.2019.3/xsdps_hw.h
@@ -1213,7 +1213,9 @@
  *		u16 XSdPs_ReadReg(u32 BaseAddress. int RegOffset)
  *
  ******************************************************************************/
+#ifndef INLINE
     #define INLINE    __inline
+#endif
     static INLINE u16 XSdPs_ReadReg16( u32 BaseAddress,
                                        u8 RegOffset )
     {

--- a/portable/Zynq.2019.3/xsdps_info.c
+++ b/portable/Zynq.2019.3/xsdps_info.c
@@ -240,7 +240,7 @@ int sd_decode_csd( struct mmc_csd * pxCSD,
             m = UNSTUFF_BITS( ulResponse, 48, 22 );
             pxCSD->capacity = ( 1 + m ) << 10;
 
-            FF_PRINTF( "capacity: (1 + %u) << 10  DTR %u Mhz\n", m, pxCSD->max_dtr / 1000000 );
+            FF_PRINTF( "capacity: (1 + %u) << 10  DTR %u Mhz\n", m, (unsigned)pxCSD->max_dtr / 1000000 );
 
             pxCSD->read_blkbits = 9;
             pxCSD->read_partial = 0;

--- a/portable/Zynq.2019.3/xsdps_info.c
+++ b/portable/Zynq.2019.3/xsdps_info.c
@@ -240,7 +240,7 @@ int sd_decode_csd( struct mmc_csd * pxCSD,
             m = UNSTUFF_BITS( ulResponse, 48, 22 );
             pxCSD->capacity = ( 1 + m ) << 10;
 
-            FF_PRINTF( "capacity: (1 + %u) << 10  DTR %u Mhz\n", m, ( unsigned ) pxCSD->max_dtr / 1000000 );
+            FF_PRINTF( "capacity: (1 + %u) << 10  DTR %u Mhz\n", m, (unsigned)pxCSD->max_dtr / 1000000 );
 
             pxCSD->read_blkbits = 9;
             pxCSD->read_partial = 0;

--- a/portable/Zynq.2019.3/xsdps_info.c
+++ b/portable/Zynq.2019.3/xsdps_info.c
@@ -240,7 +240,7 @@ int sd_decode_csd( struct mmc_csd * pxCSD,
             m = UNSTUFF_BITS( ulResponse, 48, 22 );
             pxCSD->capacity = ( 1 + m ) << 10;
 
-            FF_PRINTF( "capacity: (1 + %u) << 10  DTR %u Mhz\n", m, (unsigned)pxCSD->max_dtr / 1000000 );
+            FF_PRINTF( "capacity: (1 + %u) << 10  DTR %u Mhz\n", m, ( unsigned ) pxCSD->max_dtr / 1000000 );
 
             pxCSD->read_blkbits = 9;
             pxCSD->read_partial = 0;

--- a/portable/Zynq.2019.3/xsdps_options.c
+++ b/portable/Zynq.2019.3/xsdps_options.c
@@ -195,7 +195,6 @@ s32 XSdPs_Get_BusWidth( XSdPs * InstancePtr,
                         u8 * SCR )
 {
     s32 Status;
-    u32 StatusReg;
     u16 BlkCnt;
     u16 BlkSize;
     s32 LoopCnt;
@@ -432,7 +431,6 @@ s32 XSdPs_Get_BusSpeed( XSdPs * InstancePtr,
                         u8 * ReadBuff )
 {
     s32 Status;
-    u32 StatusReg;
     u32 Arg;
     u16 BlkCnt;
     u16 BlkSize;
@@ -511,7 +509,6 @@ s32 XSdPs_Get_Status( XSdPs * InstancePtr,
                       u8 * SdStatReg )
 {
     s32 Status;
-    u32 StatusReg;
     u16 BlkCnt;
     u16 BlkSize;
 
@@ -960,7 +957,6 @@ s32 XSdPs_Get_Mmc_ExtCsd( XSdPs * InstancePtr,
                           u8 * ReadBuff )
 {
     s32 Status;
-    u32 StatusReg;
     u32 Arg = 0U;
     u16 BlkCnt;
     u16 BlkSize;
@@ -1040,7 +1036,6 @@ s32 XSdPs_Set_Mmc_ExtCsd( XSdPs * InstancePtr,
                           u32 Arg )
 {
     s32 Status;
-    u32 StatusReg;
 
     Status = XSdPs_CmdTransfer( InstancePtr, CMD6, Arg, 0U );
 

--- a/portable/Zynq/xsdps.c
+++ b/portable/Zynq/xsdps.c
@@ -1523,12 +1523,10 @@ s32 XSdPs_WritePolled( XSdPs * InstancePtr,
         }
 
         XSdPs_ReadStatus( InstancePtr );
-/*		eventLogAdd("Wt %lx %lx%s", Status[0], Status[1], Status[0] != Status[1] ? " DIFF" : ""); */
     }
     else
     {
-        u32 Status = XSdPs_ReadStatus( InstancePtr );
-/*		eventLogAdd("Wt %lx", Status); */
+        XSdPs_ReadStatus( InstancePtr );
     }
 
     XSdPs_WriteReg16( InstancePtr->Config.BaseAddress,

--- a/portable/Zynq/xsdps_info.c
+++ b/portable/Zynq/xsdps_info.c
@@ -240,7 +240,7 @@ int sd_decode_csd( struct mmc_csd * pxCSD,
             m = UNSTUFF_BITS( ulResponse, 48, 22 );
             pxCSD->capacity = ( 1 + m ) << 10;
 
-            FF_PRINTF( "capacity: (1 + %u) << 10  DTR %u Mhz\n", m, pxCSD->max_dtr / 1000000 );
+            FF_PRINTF( "capacity: (1 + %u) << 10  DTR %u Mhz\n", m, (unsigned)pxCSD->max_dtr / 1000000 );
 
             pxCSD->read_blkbits = 9;
             pxCSD->read_partial = 0;


### PR DESCRIPTION
Reported by [Austin](https://forums.freertos.org/u/austin) on the [FreeRTOS forum](https://forums.freertos.org/t/freertos-fat-creates-files-with-same-long-file-name-but-with-different-short-name): when multiple tasks try to create the same long file name, multiple instances will be created, each with a different short file name.

This PR proposes to add a new semaphore called `pvSemaphoreOpen`, that protects `FF_Open()` in case a file is opened in write mode.

As a race condition is very rare, the new semaphore will not be used by default.

To summarise the change:
~~~c
FF_FILE * FF_Open( FF_IOManager_t * pxIOManager,
                   const char * pcPath,
                   uint8_t ucMode,
                   FF_Error_t * pxError )
{
    #if( ffconfigPROTECT_FF_FOPEN_WITH_SEMAPHORE == 1 )
    {
        if( ( ucMode & FF_MODE_CREATE ) != 0 )
        {
            FF_PendSemaphore( pxIOManager->pvSemaphoreOpen );
        }
    }
    #endif

    /* Create and/or open a file. */

    #if( ffconfigPROTECT_FF_FOPEN_WITH_SEMAPHORE == 1 )
    {
        if( ( ucMode & FF_MODE_CREATE ) != 0 )
        {
            FF_ReleaseSemaphore( pxIOManager->pvSemaphoreOpen );
        }
    }
    #endif
}
~~~
