### PR TITLE
Make reading from and writing to the FSINFO independent

### DIFF
--- a/ff_ioman.c
+++ b/ff_ioman.c
@@ -1509,7 +1509,7 @@ FF_Error_t FF_Mount( FF_Disk_t * pxDisk,
         }
 
         pxPartition->ulClusterBeginLBA = pxPartition->ulFATBeginLBA + ( pxPartition->ucNumFATS * pxPartition->ulSectorsPerFAT );
-        #if ( ffconfigWRITE_FREE_COUNT != 0 )
+        #if ( ffconfigWRITE_FREE_COUNT != 0 ) || ( ffconfigFSINFO_TRUSTED != 0 )
             {
                 pxPartition->ulFSInfoLBA = pxPartition->ulBeginLBA + FF_getShort( pxBuffer->pucBuffer, 48 );
             }

--- a/include/ff_ioman.h
+++ b/include/ff_ioman.h
@@ -238,7 +238,7 @@
         uint32_t ulSectorsPerFAT; /* Number of sectors per Fat. */
         uint32_t ulTotalSectors;
         uint32_t ulDataSectors;
-        #if ( ffconfigWRITE_FREE_COUNT != 0 )
+        #if ( ffconfigWRITE_FREE_COUNT != 0 ) || ( ffconfigFSINFO_TRUSTED != 0 )
             uint32_t ulFSInfoLBA; /* LBA of the FSINFO sector. */
         #endif
         uint32_t ulRootDirSectors;


### PR DESCRIPTION
Every FAT disk partition has a special sector called "FSINFO". It contains a few useful fields:

- 2 record signatures
- FSI_Free_Count (offset 488)  The number of free clusters left
- FSI_Nxt_Free (offset 492)  The address of the next free cluster

The use of these fields in FreeRTOS+FAT is optional, and there are 2 macros to determine this:
~~~c
#define ffconfigFSINFO_TRUSTED      1  // Read the 'FSI_Free_Count' and 'FSI_Nxt_Free' from disk
#define ffconfigWRITE_FREE_COUNT    1  // Update the fields when necessary
~~~

One user on the forum, [Glen English](https://forums.freertos.org/u/glenenglish), reported to me that the 2 macros are not independent.
When only `ffconfigWRITE_FREE_COUNT` is defined, the field 'ulFSInfoLBA' is missing in in the FF_Partition_t struct:

This PR proposes :

~~~diff
-    #if ( ffconfigWRITE_FREE_COUNT != 0 )
+    #if ( ffconfigWRITE_FREE_COUNT != 0 ) || ( ffconfigFSINFO_TRUSTED != 0 )
         uint32_t ulFSInfoLBA; /* LBA of the FSINFO sector. */
     #endif
~~~

And also this change:
~~~diff
-    #if ( ffconfigWRITE_FREE_COUNT != 0 )
+    #if ( ffconfigWRITE_FREE_COUNT != 0 ) || ( ffconfigFSINFO_TRUSTED != 0 )
     {
         pxPartition->ulFSInfoLBA = pxPartition->ulBeginLBA + FF_getShort( pxBuffer->pucBuffer, 48 );
     }
     #endif
~~~
