### PR TITLE
Ensure null-termination of filenames copied by strncpy

### DIFF
--- a/ff_dir.c
+++ b/ff_dir.c
@@ -1723,9 +1723,11 @@ FF_Error_t FF_PopulateLongDirent( FF_IOManager_t * pxIOManager,
                     {
                         /* Valid Dir found, copy the wildCard to filename! */
                         #if ( ffconfigUNICODE_UTF16_SUPPORT != 0 )
-                            wcsncpy( pxDirEntry->pcWildCard, ++pcWildCard, ffconfigMAX_FILENAME );
+                            wcsncpy( pxDirEntry->pcWildCard, ++pcWildCard, ffconfigMAX_FILENAME - 1 );
+                            pxDirEntry->pcWildCard[ sizeof( pxDirEntry->pcWildCard ) - 1 ] = 0;
                         #else
-                            strncpy( pxDirEntry->pcWildCard, ++pcWildCard, ffconfigMAX_FILENAME );
+                            strncpy( pxDirEntry->pcWildCard, ++pcWildCard, ffconfigMAX_FILENAME - 1 );
+                            pxDirEntry->pcWildCard[ sizeof( pxDirEntry->pcWildCard ) - 1 ] = 0;
                         #endif
 
                         if( pxDirEntry->pcWildCard[ xIndex - 1 ] == ':' )
@@ -2658,7 +2660,8 @@ int32_t FF_FindShortName( FF_IOManager_t * pxIOManager,
                         }
                         else
                         {
-                            wcsncpy( usUtf16Name, pcName, ffconfigMAX_FILENAME );
+                            wcsncpy( usUtf16Name, pcName, ffconfigMAX_FILENAME - 1 );
+                            usUtf16Name[ sizeof( usUtf16Name ) - 1 ] = 0;
                         }
                     }
                 #else /* if WCHAR_MAX <= 0xFFFF */
@@ -3127,11 +3130,13 @@ FF_Error_t FF_CreateDirent( FF_IOManager_t * pxIOManager,
 
     #if ( ffconfigUNICODE_UTF16_SUPPORT != 0 )
         {
-            wcsncpy( xMyFile.pcFileName, pcFileName, ffconfigMAX_FILENAME );
+            wcsncpy( xMyFile.pcFileName, pcFileName, ffconfigMAX_FILENAME - 1 );
+            xMyFile.pcFileName[ sizeof( xMyFile.pcFileName ) - 1 ] = 0;
         }
     #else
         {
-            strncpy( xMyFile.pcFileName, pcFileName, ffconfigMAX_FILENAME );
+            strncpy( xMyFile.pcFileName, pcFileName, ffconfigMAX_FILENAME  - 1 );
+            xMyFile.pcFileName[ sizeof( xMyFile.pcFileName ) - 1 ] = 0;
         }
     #endif
 
@@ -3310,11 +3315,13 @@ FF_Error_t FF_CreateDirent( FF_IOManager_t * pxIOManager,
 
         #if ( ffconfigUNICODE_UTF16_SUPPORT != 0 )
             {
-                wcsncpy( xMyDirectory.pcFileName, pcDirName, ffconfigMAX_FILENAME );
+                wcsncpy( xMyDirectory.pcFileName, pcDirName, ffconfigMAX_FILENAME - 1 );
+                xMyFile.pcFileName[ sizeof( xMyFile.pcFileName ) - 1 ] = 0;
             }
         #else
             {
-                strncpy( xMyDirectory.pcFileName, pcDirName, ffconfigMAX_FILENAME );
+                strncpy( xMyDirectory.pcFileName, pcDirName, ffconfigMAX_FILENAME - 1 );
+                xMyFile.pcFileName[ sizeof( xMyFile.pcFileName ) - 1 ] = 0;
             }
         #endif
 

--- a/ff_dir.c
+++ b/ff_dir.c
@@ -1723,7 +1723,7 @@ FF_Error_t FF_PopulateLongDirent( FF_IOManager_t * pxIOManager,
                     {
                         /* Valid Dir found, copy the wildCard to filename! */
                         STRNCPY( pxDirEntry->pcWildCard, ++pcWildCard, ffconfigMAX_FILENAME - 1 );
-                        pxDirEntry->pcWildCard[ sizeof( pxDirEntry->pcWildCard ) - 1 ] = 0;
+                        pxDirEntry->pcWildCard[ ffconfigMAX_FILENAME - 1 ] = 0;
 
                         if( pxDirEntry->pcWildCard[ xIndex - 1 ] == ':' )
                         {
@@ -2656,7 +2656,7 @@ int32_t FF_FindShortName( FF_IOManager_t * pxIOManager,
                         else
                         {
                             wcsncpy( usUtf16Name, pcName, ffconfigMAX_FILENAME - 1 );
-                            usUtf16Name[ sizeof( usUtf16Name ) - 1 ] = 0;
+                            usUtf16Name[ ffconfigMAX_FILENAME - 1 ] = 0;
                         }
                     }
                 #else /* if WCHAR_MAX <= 0xFFFF */
@@ -3124,7 +3124,7 @@ FF_Error_t FF_CreateDirent( FF_IOManager_t * pxIOManager,
     memset( &xMyFile, '\0', sizeof( xMyFile ) );
 
     STRNCPY( xMyFile.pcFileName, pcFileName, ffconfigMAX_FILENAME  - 1 );
-    xMyFile.pcFileName[ sizeof( xMyFile.pcFileName ) - 1 ] = 0;
+    xMyFile.pcFileName[ ffconfigMAX_FILENAME - 1 ] = 0;
 
     xMyFile.ulObjectCluster = FF_CreateClusterChain( pxIOManager, &xError );
 
@@ -3300,7 +3300,7 @@ FF_Error_t FF_CreateDirent( FF_IOManager_t * pxIOManager,
         }
 
         STRNCPY( xMyDirectory.pcFileName, pcDirName, ffconfigMAX_FILENAME - 1 );
-        xMyFile.pcFileName[ sizeof( xMyFile.pcFileName ) - 1 ] = 0;
+        xMyFile.pcFileName[ ffconfigMAX_FILENAME - 1 ] = 0;
 
         xMyDirectory.ulFileSize = 0;
         xMyDirectory.ucAttrib = FF_FAT_ATTR_DIR;

--- a/ff_dir.c
+++ b/ff_dir.c
@@ -1722,13 +1722,8 @@ FF_Error_t FF_PopulateLongDirent( FF_IOManager_t * pxIOManager,
                     if( pxDirEntry->ulDirCluster != 0 )
                     {
                         /* Valid Dir found, copy the wildCard to filename! */
-                        #if ( ffconfigUNICODE_UTF16_SUPPORT != 0 )
-                            wcsncpy( pxDirEntry->pcWildCard, ++pcWildCard, ffconfigMAX_FILENAME - 1 );
-                            pxDirEntry->pcWildCard[ sizeof( pxDirEntry->pcWildCard ) - 1 ] = 0;
-                        #else
-                            strncpy( pxDirEntry->pcWildCard, ++pcWildCard, ffconfigMAX_FILENAME - 1 );
-                            pxDirEntry->pcWildCard[ sizeof( pxDirEntry->pcWildCard ) - 1 ] = 0;
-                        #endif
+                        STRNCPY( pxDirEntry->pcWildCard, ++pcWildCard, ffconfigMAX_FILENAME - 1 );
+                        pxDirEntry->pcWildCard[ sizeof( pxDirEntry->pcWildCard ) - 1 ] = 0;
 
                         if( pxDirEntry->pcWildCard[ xIndex - 1 ] == ':' )
                         {
@@ -3128,17 +3123,8 @@ FF_Error_t FF_CreateDirent( FF_IOManager_t * pxIOManager,
 
     memset( &xMyFile, '\0', sizeof( xMyFile ) );
 
-    #if ( ffconfigUNICODE_UTF16_SUPPORT != 0 )
-        {
-            wcsncpy( xMyFile.pcFileName, pcFileName, ffconfigMAX_FILENAME - 1 );
-            xMyFile.pcFileName[ sizeof( xMyFile.pcFileName ) - 1 ] = 0;
-        }
-    #else
-        {
-            strncpy( xMyFile.pcFileName, pcFileName, ffconfigMAX_FILENAME  - 1 );
-            xMyFile.pcFileName[ sizeof( xMyFile.pcFileName ) - 1 ] = 0;
-        }
-    #endif
+    STRNCPY( xMyFile.pcFileName, pcFileName, ffconfigMAX_FILENAME  - 1 );
+    xMyFile.pcFileName[ sizeof( xMyFile.pcFileName ) - 1 ] = 0;
 
     xMyFile.ulObjectCluster = FF_CreateClusterChain( pxIOManager, &xError );
 
@@ -3313,17 +3299,8 @@ FF_Error_t FF_CreateDirent( FF_IOManager_t * pxIOManager,
             break;
         }
 
-        #if ( ffconfigUNICODE_UTF16_SUPPORT != 0 )
-            {
-                wcsncpy( xMyDirectory.pcFileName, pcDirName, ffconfigMAX_FILENAME - 1 );
-                xMyFile.pcFileName[ sizeof( xMyFile.pcFileName ) - 1 ] = 0;
-            }
-        #else
-            {
-                strncpy( xMyDirectory.pcFileName, pcDirName, ffconfigMAX_FILENAME - 1 );
-                xMyFile.pcFileName[ sizeof( xMyFile.pcFileName ) - 1 ] = 0;
-            }
-        #endif
+        STRNCPY( xMyDirectory.pcFileName, pcDirName, ffconfigMAX_FILENAME - 1 );
+        xMyFile.pcFileName[ sizeof( xMyFile.pcFileName ) - 1 ] = 0;
 
         xMyDirectory.ulFileSize = 0;
         xMyDirectory.ucAttrib = FF_FAT_ATTR_DIR;

--- a/ff_file.c
+++ b/ff_file.c
@@ -283,7 +283,8 @@ static FF_FILE * prvAllocFileHandle( FF_IOManager_t * pxIOManager,
         }
 
         /* Copy the file name, i.e. the string that comes after the last separator. */
-        STRNCPY( pcFileName, pcPath + xIndex + 1, ffconfigMAX_FILENAME );
+        STRNCPY( pcFileName, pcPath + xIndex + 1, ffconfigMAX_FILENAME - 1 );
+        pcFileName[ sizeof( pcFileName ) - 1 ] = 0;
 
         if( xIndex == 0 )
         {
@@ -957,7 +958,8 @@ static FF_FILE * prvAllocFileHandle( FF_IOManager_t * pxIOManager,
                     }
 
                     /* Copy the base name of the destination file. */
-                    STRNCPY( xMyFile.pcFileName, ( szDestinationFile + xIndex + 1 ), ffconfigMAX_FILENAME );
+                    STRNCPY( xMyFile.pcFileName, ( szDestinationFile + xIndex + 1 ), ffconfigMAX_FILENAME - 1 );
+                    xMyFile.pcFileName[ sizeof( xMyFile.pcFileName ) - 1 ] = 0;
 
                     if( xIndex == 0 )
                     {
@@ -2853,7 +2855,8 @@ FF_Error_t FF_CheckValid( FF_FILE * pxFile )
             xIndex--;
         }
 
-        STRNCPY( pcFileName, ( pcPath + xIndex + 1 ), ffconfigMAX_FILENAME );
+        STRNCPY( pcFileName, ( pcPath + xIndex + 1 ), ffconfigMAX_FILENAME - 1 );
+        pcFileName[ sizeof( pcFileName ) - 1 ] = 0;
 
         if( xIndex == 0 )
         {
@@ -2950,7 +2953,8 @@ FF_Error_t FF_CheckValid( FF_FILE * pxFile )
         xIndex--;
     }
 
-    STRNCPY( pcFileName, ( pcPath + xIndex + 1 ), ffconfigMAX_FILENAME );
+    STRNCPY( pcFileName, ( pcPath + xIndex + 1 ), ffconfigMAX_FILENAME - 1 );
+    pcFileName[ sizeof( pcFileName ) - 1 ] = 0;
 
     if( xIndex == 0 )
     {

--- a/ff_file.c
+++ b/ff_file.c
@@ -284,7 +284,7 @@ static FF_FILE * prvAllocFileHandle( FF_IOManager_t * pxIOManager,
 
         /* Copy the file name, i.e. the string that comes after the last separator. */
         STRNCPY( pcFileName, pcPath + xIndex + 1, ffconfigMAX_FILENAME - 1 );
-        pcFileName[ sizeof( pcFileName ) - 1 ] = 0;
+        pcFileName[ ffconfigMAX_FILENAME - 1 ] = 0;
 
         if( xIndex == 0 )
         {
@@ -959,7 +959,7 @@ static FF_FILE * prvAllocFileHandle( FF_IOManager_t * pxIOManager,
 
                     /* Copy the base name of the destination file. */
                     STRNCPY( xMyFile.pcFileName, ( szDestinationFile + xIndex + 1 ), ffconfigMAX_FILENAME - 1 );
-                    xMyFile.pcFileName[ sizeof( xMyFile.pcFileName ) - 1 ] = 0;
+                    xMyFile.pcFileName[ ffconfigMAX_FILENAME - 1 ] = 0;
 
                     if( xIndex == 0 )
                     {
@@ -2856,7 +2856,7 @@ FF_Error_t FF_CheckValid( FF_FILE * pxFile )
         }
 
         STRNCPY( pcFileName, ( pcPath + xIndex + 1 ), ffconfigMAX_FILENAME - 1 );
-        pcFileName[ sizeof( pcFileName ) - 1 ] = 0;
+        pcFileName[ ffconfigMAX_FILENAME - 1 ] = 0;
 
         if( xIndex == 0 )
         {
@@ -2954,7 +2954,7 @@ FF_Error_t FF_CheckValid( FF_FILE * pxFile )
     }
 
     STRNCPY( pcFileName, ( pcPath + xIndex + 1 ), ffconfigMAX_FILENAME - 1 );
-    pcFileName[ sizeof( pcFileName ) - 1 ] = 0;
+    pcFileName[ ffconfigMAX_FILENAME - 1 ] = 0;
 
     if( xIndex == 0 )
     {

--- a/ff_sys.c
+++ b/ff_sys.c
@@ -141,7 +141,8 @@ int FF_FS_Add( const char * pcPath,
             if( xUseIndex >= ( BaseType_t ) 0 )
             {
                 iReturn = pdTRUE;
-                strncpy( file_systems.xSystems[ xUseIndex ].pcPath, pcPath, sizeof( file_systems.xSystems[ xUseIndex ].pcPath ) );
+                strncpy( file_systems.xSystems[ xUseIndex ].pcPath, pcPath, sizeof( file_systems.xSystems[ xUseIndex ].pcPath ) - 1 );
+                file_systems.xSystems[ xUseIndex ].pcPath[ sizeof( file_systems.xSystems[ xUseIndex ].pcPath ) - 1 ] = 0;
                 file_systems.xSystems[ xUseIndex ].xPathlen = uxPathLength;
                 file_systems.xSystems[ xUseIndex ].pxManager = pxDisk->pxIOManager;
             }

--- a/include/FreeRTOSFATConfigDefaults.h
+++ b/include/FreeRTOSFATConfigDefaults.h
@@ -436,7 +436,8 @@
 /* Sets the maximum length for file names, including the path.
  * Note that the value of this define is directly related to the maximum stack
  * use of the +FAT library. In some API's, a character buffer of size
- * 'ffconfigMAX_FILENAME' will be declared on stack. */
+ * 'ffconfigMAX_FILENAME' will be declared on stack. As such, this value should
+ * include space for the null byte. */
     #define ffconfigMAX_FILENAME    129
 #endif
 


### PR DESCRIPTION
Prior use of strncpy passed the buffer length for n; when the string to copy is
length n or longer, this results in the buffer not containing a null byte. This
is problematic as the buffers are assumed to contain a null byte elsewhere.

Reported here: https://forums.freertos.org/t/freertos-fat-compiler-warnings/14843