### PR TITLE
Correct default definition of a config macro

### DIFF
--- a/include/FreeRTOSFATConfigDefaults.h
+++ b/include/FreeRTOSFATConfigDefaults.h
@@ -122,7 +122,7 @@
  * - UTF-8  (ffconfigUNICODE_UTF8_SUPPORT = 1)
  * - UTF-16 (ffconfigUNICODE_UTF16_SUPPORT = 1)
  */
-#if ( ffconfigUNICODE_UTF16_SUPPORT == 0 )
+#if !defined( ffconfigUNICODE_UTF16_SUPPORT )
 
 /* Only used when ffconfigLFN_SUPPORT is set to 1.
  *


### PR DESCRIPTION
The check for defining the default value of `ffconfigUNICODE_UTF16_SUPPORT` was `#if( ffconfigUNICODE_UTF16_SUPPORT == 0 )` which resulted in macro redefinition warnings if the application defined the macro to `0`. This commit changes the check to
`#if !defined( ffconfigUNICODE_UTF16_SUPPORT )` to ensure that default value if only defined when the application does not define the macro and hence, no warning is generated even when the application defines `ffconfigUNICODE_UTF16_SUPPORT` to `0`.

It was reported here - https://github.com/FreeRTOS/Lab-Project-FreeRTOS-FAT/issues/29
