### PR TITLE
Fix typo in ff_dir.c - xMyFile @ line 3303 should be xMyDirectory

### DIFF
--- a/ff_dir.c
+++ b/ff_dir.c
@@ -3300,7 +3300,7 @@ FF_Error_t FF_CreateDirent( FF_IOManager_t * pxIOManager,
         }
 
         STRNCPY( xMyDirectory.pcFileName, pcDirName, ffconfigMAX_FILENAME - 1 );
-        xMyFile.pcFileName[ ffconfigMAX_FILENAME - 1 ] = 0;
+        xMyDirectory.pcFileName[ ffconfigMAX_FILENAME - 1 ] = 0;
 
         xMyDirectory.ulFileSize = 0;
         xMyDirectory.ucAttrib = FF_FAT_ATTR_DIR;


### PR DESCRIPTION
I am really surprised no one has seen this problem before the master branch fails to compile without this change! 🙂 