### PR TITLE
Xilinx/Zynq.2019.3 Avoid race condition when waiting for status

### DIFF
--- a/portable/Zynq.2019.3/ff_sddisk.c
+++ b/portable/Zynq.2019.3/ff_sddisk.c
@@ -102,9 +102,9 @@
 #define EXT_CSD_HIGH_SPEED_BYTE           185
 #define EXT_CSD_DEVICE_TYPE_HIGH_SPEED    0x3
 
-#define HUNDRED_64_BIT                    100ULL
-#define BYTES_PER_MB                      ( 1024ull * 1024ull )
-#define SECTORS_PER_MB                    ( BYTES_PER_MB / 512ull )
+#define HUNDRED_64_BIT                    100U
+#define BYTES_PER_MB                      ( 1024U * 1024U )
+#define SECTORS_PER_MB                    ( BYTES_PER_MB / 512U )
 
 #define XSDPS_INTR_NORMAL_ENABLE                                                    \
     ( XSDPS_INTR_CC_MASK | XSDPS_INTR_TC_MASK |                                     \
@@ -242,7 +242,7 @@ static int32_t prvFFRead( uint8_t * pucBuffer,
 
             if( iResult == XST_SUCCESS )
             {
-                lReturnCode = 0l;
+                lReturnCode = 0;
             }
             else
             {
@@ -504,7 +504,10 @@ FF_Disk_t * FF_SDDiskInit( const char * pcName )
         /* Initialise the created disk structure. */
         memset( pxDisk, '\0', sizeof( *pxDisk ) );
 
-        pxDisk->ulNumberOfSectors = myCSD.sd_last_block_address + 1;
+        /* Apparently is `myCSD.sd_last_block_address` is not correct/accurate */
+
+        /*pxDisk->ulNumberOfSectors = myCSD.sd_last_block_address + 1; */
+        pxDisk->ulNumberOfSectors = pxSDCardInstance->SectorCount;
 
         if( xPlusFATMutex == NULL )
         {
@@ -666,7 +669,7 @@ BaseType_t FF_SDDiskMount( FF_Disk_t * pxDisk )
     else
     {
         pxDisk->xStatus.bIsMounted = pdTRUE;
-        FF_PRINTF( "****** FreeRTOS+FAT initialized %lu sectors\n", pxDisk->pxIOManager->xPartition.ulTotalSectors );
+        FF_PRINTF( "****** FreeRTOS+FAT initialized %u sectors\n", ( unsigned ) pxDisk->pxIOManager->xPartition.ulTotalSectors );
     }
 
     return xReturn;
@@ -769,13 +772,15 @@ BaseType_t FF_SDDiskShowPartition( FF_Disk_t * pxDisk )
         FF_PRINTF( "Partition Nr   %8u\n", pxDisk->xStatus.bPartitionNumber );
         FF_PRINTF( "Type           %8s (%u)\n", pcTypeName, pxIOManager->xPartition.ucType );
         FF_PRINTF( "VolLabel       '%8s' \n", pxIOManager->xPartition.pcVolumeLabel );
-        FF_PRINTF( "TotalSectors   %8lu\n", pxIOManager->xPartition.ulTotalSectors );
-        FF_PRINTF( "DataSectors    %8lu\n", pxIOManager->xPartition.ulDataSectors );
-        FF_PRINTF( "SecsPerCluster %8lu\n", pxIOManager->xPartition.ulSectorsPerCluster );
-        FF_PRINTF( "Size           %8lu MB\n", ulTotalSizeMB );
-        FF_PRINTF( "FreeSize       %8lu MB ( %d perc free )\n", ulFreeSizeMB, iPercentageFree );
-        FF_PRINTF( "BeginLBA       %8lu\n", pxIOManager->xPartition.ulBeginLBA );
-        FF_PRINTF( "FATBeginLBA    %8lu\n", pxIOManager->xPartition.ulFATBeginLBA );
+        FF_PRINTF( "TotalSectors   %8u x 512 = %u\n",
+                   ( unsigned ) pxIOManager->xPartition.ulTotalSectors,
+                   ( unsigned ) pxIOManager->xPartition.ulTotalSectors * 512U );
+        FF_PRINTF( "DataSectors    %8u\n", ( unsigned ) pxIOManager->xPartition.ulDataSectors );
+        FF_PRINTF( "SecsPerCluster %8u\n", ( unsigned ) pxIOManager->xPartition.ulSectorsPerCluster );
+        FF_PRINTF( "Size           %8u MB\n", ( unsigned ) ulTotalSizeMB );
+        FF_PRINTF( "FreeSize       %8u MB ( %d perc free )\n", ( unsigned ) ulFreeSizeMB, ( int ) iPercentageFree );
+        FF_PRINTF( "BeginLBA       %8u\n", ( unsigned ) pxIOManager->xPartition.ulBeginLBA );
+        FF_PRINTF( "FATBeginLBA    %8u\n", ( unsigned ) pxIOManager->xPartition.ulFATBeginLBA );
     }
 
     return xReturn;
@@ -920,7 +925,15 @@ BaseType_t FF_SDDiskInserted( BaseType_t xDriveNr )
 volatile unsigned sd_int_count = 0;
 
 #if ( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 )
+
+/* The iSR will read the status bits, copy them to
+ * ulSDInterruptStatus[], and clear the bits that
+ * were found set. */
     volatile u32 ulSDInterruptStatus[ 2 ];
+
+/* ulSDExpectedStatus[] contains the expected status
+ * bits, which is either CC, or CC|TC. */
+    volatile u32 ulSDExpectedStatus[ 2 ];
 
     void XSdPs_IntrHandler( void * XSdPsPtr )
     {
@@ -949,12 +962,10 @@ volatile unsigned sd_int_count = 0;
 
         if( xSDSemaphores[ iIndex ] != NULL )
         {
-            BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-
-            xSemaphoreGiveFromISR( xSDSemaphores[ iIndex ], &xHigherPriorityTaskWoken );
-
-            if( xHigherPriorityTaskWoken != 0 )
+            if( ( ulSDInterruptStatus[ iIndex ] & ulSDExpectedStatus[ iIndex ] ) == ulSDExpectedStatus[ iIndex ] )
             {
+                BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+                xSemaphoreGiveFromISR( xSDSemaphores[ iIndex ], &xHigherPriorityTaskWoken );
                 portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
             }
         }
@@ -963,12 +974,28 @@ volatile unsigned sd_int_count = 0;
 /*-----------------------------------------------------------*/
 
 #if ( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 )
-    void XSdPs_ClearInterrupt( XSdPs * InstancePtr )
+    void XSdPs_ClearInterrupt( XSdPs * InstancePtr,
+                               uint32_t ulMask )
     {
-        int iIndex = InstancePtr->Config.DeviceId;
+        #if ( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 )
+            SemaphoreHandle_t xSemaphore;
+        #endif
+        BaseType_t xIndex = InstancePtr->Config.DeviceId;
 
-        configASSERT( iIndex <= 1 );
-        ulSDInterruptStatus[ iIndex ] = 0;
+        configASSERT( xIndex <= 1 );
+        ulSDInterruptStatus[ xIndex ] = 0U;
+        ulSDExpectedStatus[ xIndex ] = ulMask;
+
+        #if ( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 )
+            xSemaphore = xSDSemaphores[ xIndex ];
+
+            if( ( xSemaphore != NULL ) &&
+                ( uxQueueMessagesWaiting( xSemaphore ) == pdTRUE ) )
+            {
+                /* Make sure that the semaphore is initially taken. */
+                xSemaphoreTake( xSemaphore, 0U );
+            }
+        #endif
     }
 #endif /* ffconfigSDIO_DRIVER_USES_INTERRUPT */
 /*-----------------------------------------------------------*/
@@ -981,13 +1008,18 @@ volatile unsigned sd_int_count = 0;
                              u32 ulMask,
                              u32 ulWait )
     {
-        u32 ulStatusReg;
+        TickType_t xStartTime = xTaskGetTickCount();
+        u32 ulStatusReg = 0U;
         int iIndex = InstancePtr->Config.DeviceId;
         TickType_t xRemainingTime = pdMS_TO_TICKS( sdWAIT_INT_TIME_OUT_MS );
         TimeOut_t xTimeOut;
+        u32 ulBitMask = ulMask & ( XSDPS_INTR_CC_MASK | XSDPS_INTR_TC_MASK );
 
-        if( ulWait == 0UL )
+        if( ulWait == 0U )
         {
+            /* The command is CMD1, which is not implemented on
+             * an SD-card, and thus should fail. Make the time-out shorter
+             * than usual. */
             xRemainingTime = pdMS_TO_TICKS( sdQUICK_WAIT_INT_TIME_OUT_MS );
         }
 
@@ -999,34 +1031,59 @@ volatile unsigned sd_int_count = 0;
          * 1. Expected bit (ulMask) becomes high
          * 2. Time-out reached (normally 2 seconds)
          */
-        do
-        {
-            if( xRemainingTime != 0 )
-            {
-                xSemaphoreTake( xSDSemaphores[ iIndex ], xRemainingTime );
-            }
 
+        for( ; ; )
+        {
             ulStatusReg = ulSDInterruptStatus[ iIndex ];
+
+            if( ( ulStatusReg & ulBitMask ) == ulBitMask )
+            {
+                /* The desired state is reached. */
+                break;
+            }
 
             if( ( ulStatusReg & XSDPS_INTR_ERR_MASK ) != 0 )
             {
                 break;
             }
-        }
-        while( ( xTaskCheckForTimeOut( &xTimeOut, &xRemainingTime ) == pdFALSE ) &&
-               ( ( ulStatusReg & ulMask ) == 0 ) );
 
-        if( ( ulStatusReg & ulMask ) == 0 )
+            if( ( xRemainingTime == 0U ) || ( xTaskCheckForTimeOut( &xTimeOut, &xRemainingTime ) == pdTRUE ) )
+            {
+                /* The command or transfer timed out. */
+                break;
+            }
+
+            xSemaphoreTake( xSDSemaphores[ iIndex ], xRemainingTime );
+        }
+
+        /* Added by Sid: This delay is what stopped the race condition that I was seeing */
+        /* vTaskDelay(1); */
+
+        if( ( ulStatusReg & ulBitMask ) != ulBitMask )
         {
             ulStatusReg = XSdPs_ReadReg( InstancePtr->Config.BaseAddress, XSDPS_NORM_INTR_STS_OFFSET );
+            FF_PRINTF( "%s: XSdPs_WaitInterrupt = 0x%02x\r\n", __func__, ulStatusReg );
 
-            if( ulWait != 0UL )
+            /* Avoid logging about the 'CMD1' command which always fails on an SD-card. */
+            if( ulWait != 0U )
             {
                 FF_PRINTF( "XSdPs_WaitInterrupt[ %d ]: Got %08lx, expect %08lx ints: %d\n",
                            iIndex,
                            ulStatusReg,
                            ulMask,
                            sd_int_count );
+            }
+        }
+
+        if( ulWait != 0U )
+        {
+            TickType_t xEndTime = xTaskGetTickCount();
+            TickType_t xDiff = xEndTime - xStartTime;
+
+            if( xDiff >= 1000U )
+            {
+                FF_PRINTF( "XSdPs_WaitInterrupt: delta = %u ( %08X %08X )\n",
+                           ( unsigned ) xDiff, ( unsigned ) ulStatusReg, ( unsigned ) ulSDInterruptStatus[ iIndex ] );
             }
         }
 

--- a/portable/Zynq.2019.3/xsdps.c
+++ b/portable/Zynq.2019.3/xsdps.c
@@ -182,20 +182,8 @@ extern s32 XSdPs_Uhs_ModeInit( XSdPs * InstancePtr,
 static s32 XSdPs_IdentifyCard( XSdPs * InstancePtr );
 static s32 XSdPs_Switch_Voltage( XSdPs * InstancePtr );
 
-#if ( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 )
-
-/* Declared in ff_sddisk.c :
- * Function will sleep and get interrupted on a change of
- * the status register.  It will loop until:
- *  1. Expected bit (ulMask) becomes high
- *  2. Time-out reached (normally 2 seconds)
- */
-    extern u32 XSdPs_WaitInterrupt( XSdPs * InstancePtr,
-                                    u32 ulMask,
-                                    u32 ulWait );
-    /* Clear the interrupt before using it. */
-    extern void XSdPs_ClearInterrupt( XSdPs * InstancePtr );
-#else
+#if ( ffconfigSDIO_DRIVER_USES_INTERRUPT == 0 )
+    /* The polling version of this driver is not well tested. */
     #error Please define ffconfigSDIO_DRIVER_USES_INTERRUPT
 #endif
 
@@ -704,7 +692,7 @@ s32 XSdPs_SdCardInitialize( XSdPs * InstancePtr )
         }
     #endif /* 0 */
 
-    FF_PRINTF( "Sector count %lu\n", InstancePtr->SectorCount );
+    FF_PRINTF( "Sector count %u myCSD.capacity %u\n", ( unsigned ) InstancePtr->SectorCount, ( unsigned ) myCSD.capacity );
     Status = XST_SUCCESS;
 
 RETURN_PATH:
@@ -1389,11 +1377,19 @@ s32 XSdPs_Wait_For( XSdPs * InstancePtr,
     #if ( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 )
         StatusReg = XSdPs_WaitInterrupt( InstancePtr, XSDPS_INTR_ERR_MASK | Mask, Wait );
 
+        if( ( StatusReg & XSDPS_INTR_ERR_MASK ) != 0U )
+        {
+            /* Write to clear error bits */
+            XSdPs_WriteReg16( InstancePtr->Config.BaseAddress,
+                              XSDPS_ERR_INTR_STS_OFFSET,
+                              XSDPS_ERROR_INTR_ALL_MASK );
+        }
+
         if( ( StatusReg & Mask ) == 0 )
         {
             Status = XST_FAILURE;
         }
-    #else
+    #else /* if ( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 ) */
 
         /*
          * Check for transfer complete
@@ -1468,6 +1464,15 @@ s32 XSdPs_CmdTransfer( XSdPs * InstancePtr,
     u32 PresentStateReg;
     u32 CommandReg;
     s32 Status;
+    uint32_t ulMask;
+
+    ulMask = XSDPS_INTR_CC_MASK;
+
+    if( ( Cmd == CMD18 ) || ( Cmd == CMD25 ) )
+    {
+        /* The commands 18 and 25 also expect a Transfer Complete interrupt. */
+        ulMask |= XSDPS_INTR_TC_MASK;
+    }
 
     Xil_AssertNonvoid( InstancePtr != NULL );
     Xil_AssertNonvoid( InstancePtr->IsReady == XIL_COMPONENT_IS_READY );
@@ -1522,14 +1527,17 @@ s32 XSdPs_CmdTransfer( XSdPs * InstancePtr,
     }
 
     #if ( ffconfigSDIO_DRIVER_USES_INTERRUPT != 0 )
-        XSdPs_ClearInterrupt( InstancePtr );
+
+        /* Clear the status bits and tell which status bits
+         * are ex[ected in the next transaction. */
+        XSdPs_ClearInterrupt( InstancePtr, ulMask );
     #endif
     XSdPs_WriteReg( InstancePtr->Config.BaseAddress, XSDPS_XFER_MODE_OFFSET,
                     ( CommandReg << 16 ) | TransferMode );
 /*	XSdPs_WriteReg16(InstancePtr->Config.BaseAddress, XSDPS_CMD_OFFSET, */
 /*			(u16)CommandReg); */
 
-    Status = XSdPs_Wait_For( InstancePtr, XSDPS_INTR_CC_MASK, Cmd != CMD1 );
+    Status = XSdPs_Wait_For( InstancePtr, ulMask, Cmd != CMD1 );
 
 RETURN_PATH:
 
@@ -1892,21 +1900,15 @@ s32 XSdPs_ReadPolled( XSdPs * InstancePtr,
     /* Send multiple blocks read command */
     Status = XSdPs_CmdTransfer( InstancePtr, CMD18, Arg, BlkCnt );
 
-    if( Status != XST_SUCCESS )
+    if( Status == XST_SUCCESS )
+    {
+        XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
+                       XSDPS_RESP0_OFFSET );
+    }
+    else
     {
         Status = XST_FAILURE;
-        goto RETURN_PATH;
     }
-
-    Status = XSdPs_Wait_For( InstancePtr, XSDPS_INTR_TC_MASK, pdTRUE );
-
-    if( Status != XST_SUCCESS )
-    {
-        goto RETURN_PATH;
-    }
-
-    XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
-                   XSDPS_RESP0_OFFSET );
 
 RETURN_PATH:
     return Status;
@@ -2037,14 +2039,6 @@ s32 XSdPs_WritePolled( XSdPs * InstancePtr,
 
     /* Send multiple blocks write command */
     Status = XSdPs_CmdTransfer( InstancePtr, CMD25, Arg, BlkCnt );
-
-    if( Status != XST_SUCCESS )
-    {
-        Status = XST_FAILURE;
-        goto RETURN_PATH;
-    }
-
-    Status = XSdPs_Wait_For( InstancePtr, XSDPS_INTR_TC_MASK, pdTRUE );
 
 RETURN_PATH:
     return Status;

--- a/portable/Zynq.2019.3/xsdps.h
+++ b/portable/Zynq.2019.3/xsdps.h
@@ -153,7 +153,6 @@
  *
  ******************************************************************************/
 
-
 #ifndef SDPS_H_
     #define SDPS_H_
 
@@ -304,9 +303,28 @@ void XSdPs_Idle( XSdPs * InstancePtr );
                                       u32 CardType );
     #endif /* if defined( ARMR5 ) || defined( __aarch64__ ) || defined( ARMA53_32 ) || defined( __MICROBLAZE__ ) */
 
+/* Make sure that the stored status is in ulSDInterruptStatus[] is cleared.
+ * ulMask are the status bits that should come high: either CC or CC|TC. */
+void XSdPs_ClearInterrupt( XSdPs * InstancePtr,
+                           uint32_t ulMask );
+
+/* Wait for an interrupt and return the 32 bits of the status register.
+ * A return value of 0 means: time-out. */
+u32 XSdPs_WaitInterrupt( XSdPs * InstancePtr,
+                         u32 ulMask,
+                         u32 ulWait );
+
+s32 XSdPs_Wait_For( XSdPs * InstancePtr,
+                    u32 Mask,
+                    u32 Wait );
+u32 XSdPs_ReadStatus( XSdPs * InstancePtr );
+
+u32 UNSTUFF_BITS( u32 * ulResponse,
+                  int iFirst,
+                  int iSize );
     #ifdef __cplusplus
     }
     #endif
 
-#endif /* SD_H_ */
+#endif /* SDPS_H_ */
 /** @} */

--- a/portable/Zynq.2019.3/xsdps_options.c
+++ b/portable/Zynq.2019.3/xsdps_options.c
@@ -195,7 +195,6 @@ s32 XSdPs_Get_BusWidth( XSdPs * InstancePtr,
                         u8 * SCR )
 {
     s32 Status;
-    u32 StatusReg;
     u16 BlkCnt;
     u16 BlkSize;
     s32 LoopCnt;
@@ -432,7 +431,6 @@ s32 XSdPs_Get_BusSpeed( XSdPs * InstancePtr,
                         u8 * ReadBuff )
 {
     s32 Status;
-    u32 StatusReg;
     u32 Arg;
     u16 BlkCnt;
     u16 BlkSize;
@@ -511,7 +509,6 @@ s32 XSdPs_Get_Status( XSdPs * InstancePtr,
                       u8 * SdStatReg )
 {
     s32 Status;
-    u32 StatusReg;
     u16 BlkCnt;
     u16 BlkSize;
 
@@ -960,7 +957,6 @@ s32 XSdPs_Get_Mmc_ExtCsd( XSdPs * InstancePtr,
                           u8 * ReadBuff )
 {
     s32 Status;
-    u32 StatusReg;
     u32 Arg = 0U;
     u16 BlkCnt;
     u16 BlkSize;
@@ -1040,7 +1036,6 @@ s32 XSdPs_Set_Mmc_ExtCsd( XSdPs * InstancePtr,
                           u32 Arg )
 {
     s32 Status;
-    u32 StatusReg;
 
     Status = XSdPs_CmdTransfer( InstancePtr, CMD6, Arg, 0U );
 


### PR DESCRIPTION
About a year ago, there was a long conversation on the FreeRTOS Forum about [+TCP +FAT FTP server slow transfer](https://forums.freertos.org/t/tcp-fat-ftp-server-slow-transfer/11703).

[Siddhant Modi](https://forums.freertos.org/u/sidmodi) wrote that while reading from disk, sometimes a time-out occurs. For me it was difficult to replicate, it looked like a race condition between device and the user task.
Only this weekend I found a solution, which was tested successfully.

Thank you Sid for your patience, and for reporting and helping to solve the problem.

Some changes to the driver for Xilinx/Zynq.2019.3

It has a few minor MISRA changes like :
~~~diff
-#define BYTES_PER_MB                      ( 1024 * 1024 )
+#define BYTES_PER_MB                      ( 1024U * 1024U )
~~~

I already used the following change for a long time:
~~~diff
-    pxDisk->ulNumberOfSectors = myCSD.sd_last_block_address + 1;
+    pxDisk->ulNumberOfSectors = pxSDCardInstance->SectorCount;
~~~
Apparently is `myCSD.sd_last_block_address` is not correct/accurate.


**Solving the race condition**:

There are two types of interrupts: Command Complete (CC) and Transfer Complete (TC) interrupt.
After issuing a command like "Set block size", only a CC interrupt is expected.
After reading or writing data, both interrupts are expected: a CC followed by TC interrupt.

The interrupt handler `XSdPs_IntrHandler()` sets a semaphore after every status change. The user code then checks if the desired action is completed in the function `XSdPs_WaitInterrupt()`.

Some changes that I made:

Before sending the command, `XSdPs_ClearInterrupt()` is called to clear `ulSDInterruptStatus[]`, which is a copy of the register status.
Now it will also Take the semaphore in case it was give to:
~~~c
if( uxQueueMessagesWaiting( xSemaphore ) == pdTRUE )
{
    /* Make sure that the semaphore is initially taken. */
    xSemaphoreTake( xSemaphore, 0U );
}
~~~ 
This avoid a useless wakeup when calling `xSemaphoreTake()`.

And beside that, a new variable `ulSDExpectedStatus[]` is set to the expected mask:
~~~c
    ulMask = XSDPS_INTR_CC_MASK;
    if( ( Cmd == CMD18 ) || ( Cmd == CMD25 ) )
    {
        /* The commands 18 and 25 also expect a Transfer Complete interrupt. */
        ulMask |= XSDPS_INTR_TC_MASK;
    }
~~~

After sending the command, `XSdPs_WaitInterrupt()` will only be called once (in stead of twice), to wait for both `XSDPS_INTR_CC_MASK` and `XSDPS_INTR_TC_MASK`.
The interrupt will only give 1 time to the semaphore, when the complete status (either CC or CC|TC) has been reached.

We checked the changes by reading 1MB files from disk for 24 hours. Before the patch, a timeout would occur occasionally during a read.

