### PR TITLE
Fix various warnings that appear under certain configurations.

### DIFF
--- a/ff_stdio.c
+++ b/ff_stdio.c
@@ -88,7 +88,7 @@ int prvFFErrorToErrno( FF_Error_t xError );
     typedef struct WORKING_DIR
     {
         char pcCWD[ ffconfigMAX_FILENAME ];      /* The current working directory. */
-        char pcFileName[ ffconfigMAX_FILENAME ]; /* The created absolute path. */
+        char pcFileName[ ffconfigMAX_FILENAME+1 ]; /* The created absolute path. */
     } WorkingDirectory_t;
 
 /*

--- a/portable/Zynq.2019.3/ff_sddisk.c
+++ b/portable/Zynq.2019.3/ff_sddisk.c
@@ -407,7 +407,7 @@ static CacheMemoryInfo_t * pucGetSDIOCacheMemory( BaseType_t xPartition )
 
     if( ( xPartition < 0 ) || ( xPartition >= ffconfigMAX_PARTITIONS ) )
     {
-        FF_PRINTF( "pucGetSDIOCacheMemory: bad partition number: %d ( max %d )\n", xPartition, ffconfigMAX_PARTITIONS - 1 );
+        FF_PRINTF( "pucGetSDIOCacheMemory: bad partition number: %ld ( max %d )\n", xPartition, ffconfigMAX_PARTITIONS - 1 );
         xReturn = NULL;
     }
     else if( pxCacheMemories[ xPartition ] == NULL )

--- a/portable/Zynq.2019.3/xsdps.c
+++ b/portable/Zynq.2019.3/xsdps.c
@@ -441,7 +441,7 @@ s32 XSdPs_SdCardInitialize( XSdPs * InstancePtr )
     u32 CSD[ 4 ];
     u32 Arg;
     u8 ReadReg;
-    u32 BlkLen, DeviceSize, Mult;
+//    u32 BlkLen, DeviceSize, Mult;
 
     Xil_AssertNonvoid( InstancePtr != NULL );
     Xil_AssertNonvoid( InstancePtr->IsReady == XIL_COMPONENT_IS_READY );
@@ -480,7 +480,7 @@ s32 XSdPs_SdCardInitialize( XSdPs * InstancePtr )
         goto RETURN_PATH;
     }
 
-    FF_PRINTF( "CMD0 : %d\n", Status );
+    FF_PRINTF( "CMD0 : %ld\n", Status );
 
     /*
      * CMD8; response expected
@@ -488,7 +488,7 @@ s32 XSdPs_SdCardInitialize( XSdPs * InstancePtr )
      */
     Status = XSdPs_CmdTransfer( InstancePtr, CMD8,
                                 XSDPS_CMD8_VOL_PATTERN, 0U );
-    FF_PRINTF( "CMD8 : %d\n", Status );
+    FF_PRINTF( "CMD8 : %ld\n", Status );
 
     if( ( Status != XST_SUCCESS ) && ( Status != XSDPS_CT_ERROR ) )
     {

--- a/portable/Zynq.2019.3/xsdps.h
+++ b/portable/Zynq.2019.3/xsdps.h
@@ -290,6 +290,9 @@ s32 XSdPs_Get_Mmc_ExtCsd( XSdPs * InstancePtr,
 s32 XSdPs_Set_Mmc_ExtCsd( XSdPs * InstancePtr,
                           u32 Arg );
 void XSdPs_Idle( XSdPs * InstancePtr );
+s32 XSdPs_Wait_For( XSdPs * InstancePtr,
+                    u32 Mask,
+                    u32 Wait );
     #if defined( ARMR5 ) || defined( __aarch64__ ) || defined( ARMA53_32 ) || defined( __MICROBLAZE__ )
     void XSdPs_Identify_UhsMode( XSdPs * InstancePtr,
                                  u8 * ReadBuff );

--- a/portable/Zynq.2019.3/xsdps_g.c
+++ b/portable/Zynq.2019.3/xsdps_g.c
@@ -55,11 +55,18 @@
 /*
  * The configuration table for devices
  */
-
+#ifndef XPAR_XSDPS_0_BUS_WIDTH
 #define XPAR_XSDPS_0_BUS_WIDTH            0 /* XSDPS_4_BIT_WIDTH */
+#endif
+#ifndef XPAR_XSDPS_0_MIO_BANK
 #define XPAR_XSDPS_0_MIO_BANK             0
+#endif
+#ifndef XPAR_XSDPS_0_HAS_EMIO
 #define XPAR_XSDPS_0_HAS_EMIO             0
+#endif
+#ifndef XPAR_XSDPS_0_IS_CACHE_COHERENT
 #define XPAR_XSDPS_0_IS_CACHE_COHERENT    1 /* 0 Tables are located in uncached memory */
+#endif
 
 XSdPs_Config XSdPs_ConfigTable[] =
 {

--- a/portable/Zynq.2019.3/xsdps_hw.h
+++ b/portable/Zynq.2019.3/xsdps_hw.h
@@ -1213,7 +1213,9 @@
  *		u16 XSdPs_ReadReg(u32 BaseAddress. int RegOffset)
  *
  ******************************************************************************/
-    #define INLINE    __inline
+#ifndef INLINE
+        #define INLINE    __inline
+#endif
     static INLINE u16 XSdPs_ReadReg16( u32 BaseAddress,
                                        u8 RegOffset )
     {

--- a/portable/Zynq.2019.3/xsdps_info.c
+++ b/portable/Zynq.2019.3/xsdps_info.c
@@ -240,7 +240,7 @@ int sd_decode_csd( struct mmc_csd * pxCSD,
             m = UNSTUFF_BITS( ulResponse, 48, 22 );
             pxCSD->capacity = ( 1 + m ) << 10;
 
-            FF_PRINTF( "capacity: (1 + %u) << 10  DTR %u Mhz\n", m, pxCSD->max_dtr / 1000000 );
+            FF_PRINTF( "capacity: (1 + %u) << 10  DTR %lu Mhz\n", m, pxCSD->max_dtr / 1000000 );
 
             pxCSD->read_blkbits = 9;
             pxCSD->read_partial = 0;

--- a/portable/Zynq.2019.3/xsdps_options.c
+++ b/portable/Zynq.2019.3/xsdps_options.c
@@ -195,7 +195,7 @@ s32 XSdPs_Get_BusWidth( XSdPs * InstancePtr,
                         u8 * SCR )
 {
     s32 Status;
-    u32 StatusReg;
+//    u32 StatusReg;
     u16 BlkCnt;
     u16 BlkSize;
     s32 LoopCnt;
@@ -432,7 +432,7 @@ s32 XSdPs_Get_BusSpeed( XSdPs * InstancePtr,
                         u8 * ReadBuff )
 {
     s32 Status;
-    u32 StatusReg;
+//    u32 StatusReg;
     u32 Arg;
     u16 BlkCnt;
     u16 BlkSize;
@@ -511,7 +511,7 @@ s32 XSdPs_Get_Status( XSdPs * InstancePtr,
                       u8 * SdStatReg )
 {
     s32 Status;
-    u32 StatusReg;
+//    u32 StatusReg;
     u16 BlkCnt;
     u16 BlkSize;
 
@@ -960,7 +960,7 @@ s32 XSdPs_Get_Mmc_ExtCsd( XSdPs * InstancePtr,
                           u8 * ReadBuff )
 {
     s32 Status;
-    u32 StatusReg;
+//    u32 StatusReg;
     u32 Arg = 0U;
     u16 BlkCnt;
     u16 BlkSize;
@@ -1040,7 +1040,7 @@ s32 XSdPs_Set_Mmc_ExtCsd( XSdPs * InstancePtr,
                           u32 Arg )
 {
     s32 Status;
-    u32 StatusReg;
+//    u32 StatusReg;
 
     Status = XSdPs_CmdTransfer( InstancePtr, CMD6, Arg, 0U );
 


### PR DESCRIPTION
I use this repository with the Zynq7000 processors and I have found a number of warnings appear whilst compiling. I have updated the code to eliminate the warnings with a focus on the Zynq.2019.3 folder as this is the most up to date version.  Hope it's okay.

Cheers,

Pete