### PR TITLE
Fix some warnings and re-enabled previously commented out, but now required code.

### DIFF
--- a/ff_stdio.c
+++ b/ff_stdio.c
@@ -2141,8 +2141,11 @@ int prvFFErrorToErrno( FF_Error_t xError )
             if( pxWorkingDirectory->pcCWD[ 1 ] == 0x00 )
             {
                 /* In the root, so don't add a '/' between the CWD and the
-                 * file name. */
-                snprintf( pxWorkingDirectory->pcFileName, ffconfigMAX_FILENAME - 1, "/%s", pcPath );
+                 * file name.
+            	 * The length parameter also needs a -1 here because we are adding the '/' which would cause
+            	 * truncation on a full file path length it silences the associated compiler warning.
+            	 */
+                snprintf( pxWorkingDirectory->pcFileName, sizeof( pxWorkingDirectory->pcFileName ) - 1, "/%s", pcPath );
             }
             else
             {

--- a/ff_stdio.c
+++ b/ff_stdio.c
@@ -87,7 +87,10 @@ int prvFFErrorToErrno( FF_Error_t xError );
  * to extend relative paths to absolute paths. */
     typedef struct WORKING_DIR
     {
-        char pcCWD[ ffconfigMAX_FILENAME ];      /* The current working directory. */
+        char pcCWD[ ffconfigMAX_FILENAME-2 ];		/* The current working directory.  To eliminate warnings in path building
+        											 * code below we make this ffconfigMAX_FILENAME-2. In reality you would have
+        											 * a least one character for filename and one for '/' so this not unreasonable.
+        											 */
         char pcFileName[ ffconfigMAX_FILENAME ]; /* The created absolute path. */
     } WorkingDirectory_t;
 
@@ -2139,7 +2142,7 @@ int prvFFErrorToErrno( FF_Error_t xError )
             {
                 /* In the root, so don't add a '/' between the CWD and the
                  * file name. */
-                snprintf( pxWorkingDirectory->pcFileName, sizeof( pxWorkingDirectory->pcFileName ), "/%s", pcPath );
+                snprintf( pxWorkingDirectory->pcFileName, ffconfigMAX_FILENAME - 1, "/%s", pcPath );
             }
             else
             {

--- a/portable/Zynq.2019.3/ff_sddisk.c
+++ b/portable/Zynq.2019.3/ff_sddisk.c
@@ -407,7 +407,7 @@ static CacheMemoryInfo_t * pucGetSDIOCacheMemory( BaseType_t xPartition )
 
     if( ( xPartition < 0 ) || ( xPartition >= ffconfigMAX_PARTITIONS ) )
     {
-        FF_PRINTF( "pucGetSDIOCacheMemory: bad partition number: %d ( max %d )\n", xPartition, ffconfigMAX_PARTITIONS - 1 );
+        FF_PRINTF( "pucGetSDIOCacheMemory: bad partition number: %d ( max %d )\n", (int)xPartition, ffconfigMAX_PARTITIONS - 1 );
         xReturn = NULL;
     }
     else if( pxCacheMemories[ xPartition ] == NULL )
@@ -1062,7 +1062,7 @@ volatile unsigned sd_int_count = 0;
         if( ( ulStatusReg & ulBitMask ) != ulBitMask )
         {
             ulStatusReg = XSdPs_ReadReg( InstancePtr->Config.BaseAddress, XSDPS_NORM_INTR_STS_OFFSET );
-            FF_PRINTF( "%s: XSdPs_WaitInterrupt = 0x%02x\r\n", __func__, ulStatusReg );
+            FF_PRINTF( "%s: XSdPs_WaitInterrupt = 0x%02x\r\n", __func__, (unsigned)ulStatusReg );
 
             /* Avoid logging about the 'CMD1' command which always fails on an SD-card. */
             if( ulWait != 0U )

--- a/portable/Zynq.2019.3/xsdps.c
+++ b/portable/Zynq.2019.3/xsdps.c
@@ -468,7 +468,7 @@ s32 XSdPs_SdCardInitialize( XSdPs * InstancePtr )
         goto RETURN_PATH;
     }
 
-    FF_PRINTF( "CMD0 : %d\n", Status );
+    FF_PRINTF( "CMD0 : %d\n", (int)Status );
 
     /*
      * CMD8; response expected
@@ -476,7 +476,7 @@ s32 XSdPs_SdCardInitialize( XSdPs * InstancePtr )
      */
     Status = XSdPs_CmdTransfer( InstancePtr, CMD8,
                                 XSDPS_CMD8_VOL_PATTERN, 0U );
-    FF_PRINTF( "CMD8 : %d\n", Status );
+    FF_PRINTF( "CMD8 : %d\n", (int)Status );
 
     if( ( Status != XST_SUCCESS ) && ( Status != XSDPS_CT_ERROR ) )
     {
@@ -656,41 +656,35 @@ s32 XSdPs_SdCardInitialize( XSdPs * InstancePtr )
         mmc_decode_cid( &myCSD, &myCID, resp );
     }
 
-    /*
-     * Card specific data is read.
-     * Currently not used for any operation.
-     */
-    #if 0
-        CSD[ 0 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
-                                  XSDPS_RESP0_OFFSET );
-        CSD[ 1 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
-                                  XSDPS_RESP1_OFFSET );
-        CSD[ 2 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
-                                  XSDPS_RESP2_OFFSET );
-        CSD[ 3 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
-                                  XSDPS_RESP3_OFFSET );
+	CSD[ 0 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
+							  XSDPS_RESP0_OFFSET );
+	CSD[ 1 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
+							  XSDPS_RESP1_OFFSET );
+	CSD[ 2 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
+							  XSDPS_RESP2_OFFSET );
+	CSD[ 3 ] = XSdPs_ReadReg( InstancePtr->Config.BaseAddress,
+							  XSDPS_RESP3_OFFSET );
 
-        if( ( ( CSD[ 3 ] & CSD_STRUCT_MASK ) >> 22U ) == 0U )
-        {
-            BlkLen = 1U << ( ( u32 ) ( CSD[ 2 ] & READ_BLK_LEN_MASK ) >> 8U );
-            Mult = 1U << ( ( u32 ) ( ( CSD[ 1 ] & C_SIZE_MULT_MASK ) >> 7U ) + 2U );
-            DeviceSize = ( CSD[ 1 ] & C_SIZE_LOWER_MASK ) >> 22U;
-            DeviceSize |= ( CSD[ 2 ] & C_SIZE_UPPER_MASK ) << 10U;
-            DeviceSize = ( DeviceSize + 1U ) * Mult;
-            DeviceSize = DeviceSize * BlkLen;
-            InstancePtr->SectorCount = ( DeviceSize / XSDPS_BLK_SIZE_512_MASK );
-        }
-        else if( ( ( CSD[ 3 ] & CSD_STRUCT_MASK ) >> 22U ) == 1U )
-        {
-            InstancePtr->SectorCount = ( ( ( CSD[ 1 ] & CSD_V2_C_SIZE_MASK ) >> 8U ) +
-                                         1U ) * 1024U;
-        }
-        else
-        {
-            Status = XST_FAILURE;
-            goto RETURN_PATH;
-        }
-    #endif /* 0 */
+	if( ( ( CSD[ 3 ] & CSD_STRUCT_MASK ) >> 22U ) == 0U )
+	{
+		BlkLen = 1U << ( ( u32 ) ( CSD[ 2 ] & READ_BLK_LEN_MASK ) >> 8U );
+		Mult = 1U << ( ( u32 ) ( ( CSD[ 1 ] & C_SIZE_MULT_MASK ) >> 7U ) + 2U );
+		DeviceSize = ( CSD[ 1 ] & C_SIZE_LOWER_MASK ) >> 22U;
+		DeviceSize |= ( CSD[ 2 ] & C_SIZE_UPPER_MASK ) << 10U;
+		DeviceSize = ( DeviceSize + 1U ) * Mult;
+		DeviceSize = DeviceSize * BlkLen;
+		InstancePtr->SectorCount = ( DeviceSize / XSDPS_BLK_SIZE_512_MASK );
+	}
+	else if( ( ( CSD[ 3 ] & CSD_STRUCT_MASK ) >> 22U ) == 1U )
+	{
+		InstancePtr->SectorCount = ( ( ( CSD[ 1 ] & CSD_V2_C_SIZE_MASK ) >> 8U ) +
+									 1U ) * 1024U;
+	}
+	else
+	{
+		Status = XST_FAILURE;
+		goto RETURN_PATH;
+	}
 
     FF_PRINTF( "Sector count %u myCSD.capacity %u\n", ( unsigned ) InstancePtr->SectorCount, ( unsigned ) myCSD.capacity );
     Status = XST_SUCCESS;

--- a/portable/Zynq.2019.3/xsdps_g.c
+++ b/portable/Zynq.2019.3/xsdps_g.c
@@ -59,7 +59,9 @@
 #define XPAR_XSDPS_0_BUS_WIDTH            0 /* XSDPS_4_BIT_WIDTH */
 #define XPAR_XSDPS_0_MIO_BANK             0
 #define XPAR_XSDPS_0_HAS_EMIO             0
+#ifndef XPAR_XSDPS_0_IS_CACHE_COHERENT
 #define XPAR_XSDPS_0_IS_CACHE_COHERENT    1 /* 0 Tables are located in uncached memory */
+#endif
 
 XSdPs_Config XSdPs_ConfigTable[] =
 {

--- a/portable/Zynq.2019.3/xsdps_hw.h
+++ b/portable/Zynq.2019.3/xsdps_hw.h
@@ -1213,7 +1213,9 @@
  *		u16 XSdPs_ReadReg(u32 BaseAddress. int RegOffset)
  *
  ******************************************************************************/
+#ifndef INLINE
     #define INLINE    __inline
+#endif
     static INLINE u16 XSdPs_ReadReg16( u32 BaseAddress,
                                        u8 RegOffset )
     {

--- a/portable/Zynq.2019.3/xsdps_info.c
+++ b/portable/Zynq.2019.3/xsdps_info.c
@@ -240,7 +240,7 @@ int sd_decode_csd( struct mmc_csd * pxCSD,
             m = UNSTUFF_BITS( ulResponse, 48, 22 );
             pxCSD->capacity = ( 1 + m ) << 10;
 
-            FF_PRINTF( "capacity: (1 + %u) << 10  DTR %u Mhz\n", m, pxCSD->max_dtr / 1000000 );
+            FF_PRINTF( "capacity: (1 + %u) << 10  DTR %u Mhz\n", m, (unsigned)pxCSD->max_dtr / 1000000 );
 
             pxCSD->read_blkbits = 9;
             pxCSD->read_partial = 0;

--- a/portable/Zynq/xsdps.c
+++ b/portable/Zynq/xsdps.c
@@ -1523,12 +1523,10 @@ s32 XSdPs_WritePolled( XSdPs * InstancePtr,
         }
 
         XSdPs_ReadStatus( InstancePtr );
-/*		eventLogAdd("Wt %lx %lx%s", Status[0], Status[1], Status[0] != Status[1] ? " DIFF" : ""); */
     }
     else
     {
-        u32 Status = XSdPs_ReadStatus( InstancePtr );
-/*		eventLogAdd("Wt %lx", Status); */
+        XSdPs_ReadStatus( InstancePtr );
     }
 
     XSdPs_WriteReg16( InstancePtr->Config.BaseAddress,

--- a/portable/Zynq/xsdps_info.c
+++ b/portable/Zynq/xsdps_info.c
@@ -240,7 +240,7 @@ int sd_decode_csd( struct mmc_csd * pxCSD,
             m = UNSTUFF_BITS( ulResponse, 48, 22 );
             pxCSD->capacity = ( 1 + m ) << 10;
 
-            FF_PRINTF( "capacity: (1 + %u) << 10  DTR %u Mhz\n", m, pxCSD->max_dtr / 1000000 );
+            FF_PRINTF( "capacity: (1 + %u) << 10  DTR %u Mhz\n", m, (unsigned)pxCSD->max_dtr / 1000000 );
 
             pxCSD->read_blkbits = 9;
             pxCSD->read_partial = 0;


### PR DESCRIPTION
This pull request removes a number of compiler warnings and adds some comments to explain the changes.  Also there is a block of code in portable/Zynq.2019.3/xsdps.c  which was previously commented out with a '#if 0' directive which now appears to need re-enabling after the previous pull request [here](https://github.com/FreeRTOS/Lab-Project-FreeRTOS-FAT/pull/33) was merged.  Without this code block to read  the card specific data the SD card block count is not found and the initialisation fails.