### PR TITLE
Protect FF_Open in create mode with a new semaphore v2

### DIFF
--- a/ff_file.c
+++ b/ff_file.c
@@ -243,6 +243,15 @@ static FF_FILE * prvAllocFileHandle( FF_IOManager_t * pxIOManager,
         char pcFileName[ ffconfigMAX_FILENAME ];
     #endif
 
+    #if ( ffconfigPROTECT_FF_FOPEN_WITH_SEMAPHORE == 1 )
+        {
+            if( ( ucMode & FF_MODE_CREATE ) != 0U )
+            {
+                FF_PendSemaphore( pxIOManager->pvSemaphoreOpen );
+            }
+        }
+    #endif
+
     memset( &xFindParams, '\0', sizeof( xFindParams ) );
 
     /* Inform the functions that the entry will be created if not found. */
@@ -463,6 +472,15 @@ static FF_FILE * prvAllocFileHandle( FF_IOManager_t * pxIOManager,
 
         pxFile = NULL;
     }
+
+    #if ( ffconfigPROTECT_FF_FOPEN_WITH_SEMAPHORE == 1 )
+        {
+            if( ( ucMode & FF_MODE_CREATE ) != 0U )
+            {
+                FF_ReleaseSemaphore( pxIOManager->pvSemaphoreOpen );
+            }
+        }
+    #endif
 
     if( pxError != NULL )
     {

--- a/include/ff_ioman.h
+++ b/include/ff_ioman.h
@@ -289,6 +289,9 @@
         FF_Partition_t xPartition;   /* A partition description. */
         FF_Buffer_t * pxBuffers;     /* Pointer to an array of buffer descriptors. */
         void * pvSemaphore;          /* Pointer to a Semaphore object. (For buffer description modifications only!). */
+        #if ( ffconfigPROTECT_FF_FOPEN_WITH_SEMAPHORE == 1 )
+            void * pvSemaphoreOpen;  /* A semaphore to protect FF_Open() against race conditions. */
+        #endif
         void * FirstFile;            /* Pointer to the first File object. */
         void * xEventGroup;          /* An event group, used for locking FAT, DIR and Buffers. Replaces ucLocks. */
         uint8_t * pucCacheMem;       /* Pointer to a block of memory for the cache. */


### PR DESCRIPTION
This PR releases a change that is described in [PR #26](https://github.com/FreeRTOS/Lab-Project-FreeRTOS-FAT/pull/26).
PR #26 was closed because it was deviating too much from the master branch.

The changes have been tested before.