### PR TITLE
Fix typo in FF_CreateIOManager issue #40

### DIFF
--- a/ff_dir.c
+++ b/ff_dir.c
@@ -1129,7 +1129,7 @@ FF_Error_t FF_CleanupEntryFetch( FF_IOManager_t * pxIOManager,
  *  @brief	Make an exception for the root directory ( non FAT32 only ):
  *  @brief	Just calculate the cluster ( don't consult the actual FAT )
  *
- *	@param	pxIOManager FF_IOManager_t object that was created by FF_CreateIOManger( ).
+ *	@param	pxIOManager FF_IOManager_t object that was created by FF_CreateIOManager( ).
  *	@param	ulEntry     The sequence number of the entry of interest
  *  @param	pxContext   Context of current search
  *
@@ -1647,7 +1647,7 @@ FF_Error_t FF_PopulateLongDirent( FF_IOManager_t * pxIOManager,
  *	Note, as compatible with other similar APIs, FreeRTOS+FAT also accepts \sub1\* for the same behaviour as
  *	/sub1/.
  *
- *	@param	pxIOManager FF_IOManager_t object that was created by FF_CreateIOManger( ).
+ *	@param	pxIOManager FF_IOManager_t object that was created by FF_CreateIOManager( ).
  *	@param	pxDirEntry	FF_DirEnt_t object to store the entry information.
  *	@param	path		String to of the path to the Dir being listed.
  *
@@ -1777,7 +1777,7 @@ FF_Error_t FF_PopulateLongDirent( FF_IOManager_t * pxIOManager,
  *	All values recorded in pxDirEntry must be preserved to and between calls to
  *	FF_FindNext( ). Please see @see FF_FindFirst( ) for find initialisation.
  *
- *	@param	pxIOManager		FF_IOManager_t object that was created by FF_CreateIOManger( ).
+ *	@param	pxIOManager		FF_IOManager_t object that was created by FF_CreateIOManager( ).
  *	@param	pxDirEntry		FF_DirEnt_t object to store the entry information. ( As initialised by FF_FindFirst( )).
  *
  *	@Return FF_ERR_DEVICE_DRIVER_FAILED is device access failed.

--- a/ff_error.c
+++ b/ff_error.c
@@ -75,7 +75,7 @@
         {
             { "Unknown Function",         1                                          },
 /*----- FF_IOManager_t - The FreeRTOS+FAT I/O Manager */
-            { "FF_CreateIOManger",        FF_GETMOD_FUNC( FF_CREATEIOMAN )           },
+            { "FF_CreateIOManager",       FF_GETMOD_FUNC( FF_CREATEIOMAN )           },
             { "FF_DeleteIOManager",       FF_GETMOD_FUNC( FF_DESTROYIOMAN )          },
             { "FF_Mount",                 FF_GETMOD_FUNC( FF_MOUNT )                 },
             { "FF_Unmount",               FF_GETMOD_FUNC( FF_UNMOUNT )               },

--- a/ff_file.c
+++ b/ff_file.c
@@ -210,7 +210,7 @@ static FF_FILE * prvAllocFileHandle( FF_IOManager_t * pxIOManager,
  *	@public
  *	@brief	Opens a File for Access
  *
- *	@param	pxIOManager	FF_IOManager_t object that was created by FF_CreateIOManger().
+ *	@param	pxIOManager	FF_IOManager_t object that was created by FF_CreateIOManager().
  *	@param	pcPath		Path to the File or object.
  *	@param	ucMode		Access Mode required. Modes are a little complicated, the function FF_GetModeBits()
  *	@param	ucMode		will convert a stdio Mode string into the equivalent Mode bits for this parameter.
@@ -500,7 +500,7 @@ static FF_FILE * prvAllocFileHandle( FF_IOManager_t * pxIOManager,
  *	@public
  *	@brief	Tests if a Directory contains any other files or folders.
  *
- *	@param	pxIOManager	FF_IOManager_t object returned from the FF_CreateIOManger() function.
+ *	@param	pxIOManager	FF_IOManager_t object returned from the FF_CreateIOManager() function.
  *
  **/
 /* *INDENT-OFF* */
@@ -2660,7 +2660,7 @@ FF_Error_t FF_Seek( FF_FILE * pxFile,
  *	@public
  *	@brief	Invalidate all file handles belonging to pxIOManager
  *
- *	@param	pIoMan		FF_IOManager_t object that was created by FF_CreateIOManger().
+ *	@param	pIoMan		FF_IOManager_t object that was created by FF_CreateIOManager().
  *
  *	@return 0 if no handles were open
  *	@return >0 the amount of handles that were invalidated

--- a/ff_ioman.c
+++ b/ff_ioman.c
@@ -89,8 +89,8 @@ static BaseType_t prvHasActiveHandles( FF_IOManager_t * pxIOManager );
  *	@Return	Returns a pointer to an FF_IOManager_t type object. NULL on xError, check the contents of
  *	@Return pError
  **/
-FF_IOManager_t * FF_CreateIOManger( FF_CreationParameters_t * pxParameters,
-                                    FF_Error_t * pError )
+FF_IOManager_t * FF_CreateIOManager( FF_CreationParameters_t * pxParameters,
+                                     FF_Error_t * pError )
 {
     FF_IOManager_t * pxIOManager = NULL;
     FF_Error_t xError;
@@ -231,14 +231,14 @@ FF_IOManager_t * FF_CreateIOManger( FF_CreationParameters_t * pxParameters,
     }
 
     return pxIOManager;
-} /* FF_CreateIOManger() */
+} /* FF_CreateIOManager() */
 /*-----------------------------------------------------------*/
 
 /**
  *	@public
  *	@brief	Destroys an FF_IOManager_t object, and frees all assigned memory.
  *
- *	@param	pxIOManager	Pointer to an FF_IOManager_t object, as returned from FF_CreateIOManger.
+ *	@param	pxIOManager	Pointer to an FF_IOManager_t object, as returned from FF_CreateIOManager.
  *
  *	@Return	FF_ERR_NONE on sucess, or a documented error code on failure. (FF_ERR_NULL_POINTER)
  *
@@ -1925,7 +1925,7 @@ FF_Error_t FF_DecreaseFreeClusters( FF_IOManager_t * pxIOManager,
  *	knocking sequence for security. After the sector knock, some secure USB
  *	sticks then present a different BlockSize.
  *
- *	@param	pxIOManager		FF_IOManager_t Object returned from FF_CreateIOManger()
+ *	@param	pxIOManager		FF_IOManager_t Object returned from FF_CreateIOManager()
  *
  *	@Return	The blocksize of the partition. A value less than 0 when an error occurs.
  *	@Return	Any negative value can be cast to the FF_Error_t type.
@@ -1952,7 +1952,7 @@ int32_t FF_GetPartitionBlockSize( FF_IOManager_t * pxIOManager )
 /**
  *	@brief	Returns the number of bytes contained within the mounted partition or volume.
  *
- *	@param	pxIOManager		FF_IOManager_t Object returned from FF_CreateIOManger()
+ *	@param	pxIOManager		FF_IOManager_t Object returned from FF_CreateIOManager()
  *
  *	@Return The total number of bytes that the mounted partition or volume contains.
  *

--- a/include/FreeRTOSFATConfigDefaults.h
+++ b/include/FreeRTOSFATConfigDefaults.h
@@ -512,4 +512,13 @@
     #define FF_NOSTRCASECMP    0
 #endif
 
+/* Allow backword compatibility if desired */
+#ifndef ffconfigENABLE_BACKWARD_COMPATIBILITY
+    #define ffconfigENABLE_BACKWARD_COMPATIBILITY    1
+#endif
+
+#if ffconfigENABLE_BACKWARD_COMPATIBILITY == 1
+    #define FF_CreateIOManger    FF_CreateIOManager
+#endif /* ffconfigENABLE_BACKWARD_COMPATIBILITY */
+
 #endif /* ifndef FF_DEFAULTCONFIG_H */

--- a/include/ff_ioman.h
+++ b/include/ff_ioman.h
@@ -329,8 +329,8 @@
 /*---------- PROTOTYPES (in order of appearance). */
 
 /* PUBLIC (Interfaces): */
-    FF_IOManager_t * FF_CreateIOManger( FF_CreationParameters_t * pxParameters,
-                                        FF_Error_t * pError );
+    FF_IOManager_t * FF_CreateIOManager( FF_CreationParameters_t * pxParameters,
+                                         FF_Error_t * pError );
     FF_Error_t FF_DeleteIOManager( FF_IOManager_t * pxIOManager );
     FF_Error_t FF_Mount( FF_Disk_t * pxDisk,
                          BaseType_t xPartitionNumber );

--- a/portable/ATSAM4E/ff_sddisk.c
+++ b/portable/ATSAM4E/ff_sddisk.c
@@ -373,11 +373,11 @@ FF_Disk_t * FF_SDDiskInit( const char * pcName )
                  * prvFFRead()/prvFFWrite() from different tasks. */
                 xParameters.pvSemaphore = ( void * ) xPlusFATMutex;
 
-                pxDisk->pxIOManager = FF_CreateIOManger( &xParameters, &xFFError );
+                pxDisk->pxIOManager = FF_CreateIOManager( &xParameters, &xFFError );
 
                 if( pxDisk->pxIOManager == NULL )
                 {
-                    FF_PRINTF( "FF_SDDiskInit: FF_CreateIOManger: %s\n", ( const char * ) FF_GetErrMessage( xFFError ) );
+                    FF_PRINTF( "FF_SDDiskInit: FF_CreateIOManager: %s\n", ( const char * ) FF_GetErrMessage( xFFError ) );
                     FF_SDDiskDelete( pxDisk );
                     pxDisk = NULL;
                 }

--- a/portable/ATSAM4E/ff_sddisk_r.c
+++ b/portable/ATSAM4E/ff_sddisk_r.c
@@ -225,11 +225,11 @@ FF_Disk_t * FF_SDDiskInit( const char * pcName )
                  * prvFFRead()/prvFFWrite() from different tasks. */
                 xParameters.pvSemaphore = ( void * ) xPlusFATMutex;
 
-                pxDisk->pxIOManager = FF_CreateIOManger( &xParameters, &xFFError );
+                pxDisk->pxIOManager = FF_CreateIOManager( &xParameters, &xFFError );
 
                 if( pxDisk->pxIOManager == NULL )
                 {
-                    FF_PRINTF( "FF_SDDiskInit: FF_CreateIOManger: %s\n", ( const char * ) FF_GetErrMessage( xFFError ) );
+                    FF_PRINTF( "FF_SDDiskInit: FF_CreateIOManager: %s\n", ( const char * ) FF_GetErrMessage( xFFError ) );
                     FF_SDDiskDelete( pxDisk );
                     pxDisk = NULL;
                 }

--- a/portable/STM32F4xx/ff_sddisk.c
+++ b/portable/STM32F4xx/ff_sddisk.c
@@ -477,11 +477,11 @@ FF_Disk_t * FF_SDDiskInit( const char * pcName )
                  * prvFFRead()/prvFFWrite() from different tasks. */
                 xParameters.pvSemaphore = ( void * ) xPlusFATMutex;
 
-                pxDisk->pxIOManager = FF_CreateIOManger( &xParameters, &xFFError );
+                pxDisk->pxIOManager = FF_CreateIOManager( &xParameters, &xFFError );
 
                 if( pxDisk->pxIOManager == NULL )
                 {
-                    FF_PRINTF( "FF_SDDiskInit: FF_CreateIOManger: %s\n", ( const char * ) FF_GetErrMessage( xFFError ) );
+                    FF_PRINTF( "FF_SDDiskInit: FF_CreateIOManager: %s\n", ( const char * ) FF_GetErrMessage( xFFError ) );
                     FF_SDDiskDelete( pxDisk );
                     pxDisk = NULL;
                 }

--- a/portable/STM32F7xx/ff_sddisk.c
+++ b/portable/STM32F7xx/ff_sddisk.c
@@ -596,11 +596,11 @@ FF_Disk_t * FF_SDDiskInit( const char * pcName )
                  * prvFFRead()/prvFFWrite() from different tasks. */
                 xParameters.pvSemaphore = ( void * ) xPlusFATMutex;
 
-                pxDisk->pxIOManager = FF_CreateIOManger( &xParameters, &xFFError );
+                pxDisk->pxIOManager = FF_CreateIOManager( &xParameters, &xFFError );
 
                 if( pxDisk->pxIOManager == NULL )
                 {
-                    FF_PRINTF( "FF_SDDiskInit: FF_CreateIOManger: %s\n", ( const char * ) FF_GetErrMessage( xFFError ) );
+                    FF_PRINTF( "FF_SDDiskInit: FF_CreateIOManager: %s\n", ( const char * ) FF_GetErrMessage( xFFError ) );
                     FF_SDDiskDelete( pxDisk );
                     pxDisk = NULL;
                 }

--- a/portable/Zynq.2019.3/ff_sddisk.c
+++ b/portable/Zynq.2019.3/ff_sddisk.c
@@ -540,11 +540,11 @@ FF_Disk_t * FF_SDDiskInit( const char * pcName )
          * and also to avoid concurrent calls to prvFFRead()/prvFFWrite() from different tasks. */
         xParameters.pvSemaphore = ( void * ) xPlusFATMutex;
 
-        pxDisk->pxIOManager = FF_CreateIOManger( &xParameters, &xFFError );
+        pxDisk->pxIOManager = FF_CreateIOManager( &xParameters, &xFFError );
 
         if( pxDisk->pxIOManager == NULL )
         {
-            FF_PRINTF( "FF_SDDiskInit: FF_CreateIOManger: %s\n", ( const char * ) FF_GetErrMessage( xFFError ) );
+            FF_PRINTF( "FF_SDDiskInit: FF_CreateIOManager: %s\n", ( const char * ) FF_GetErrMessage( xFFError ) );
             FF_SDDiskDelete( pxDisk );
             pxDisk = NULL;
             break;

--- a/portable/Zynq/ff_sddisk.c
+++ b/portable/Zynq/ff_sddisk.c
@@ -444,11 +444,11 @@ FF_Disk_t * FF_SDDiskInit( const char * pcName )
              * and also to avoid concurrent calls to prvFFRead()/prvFFWrite() from different tasks. */
             xParameters.pvSemaphore = ( void * ) xPlusFATMutex;
 
-            pxDisk->pxIOManager = FF_CreateIOManger( &xParameters, &xFFError );
+            pxDisk->pxIOManager = FF_CreateIOManager( &xParameters, &xFFError );
 
             if( pxDisk->pxIOManager == NULL )
             {
-                FF_PRINTF( "FF_SDDiskInit: FF_CreateIOManger: %s\n", ( const char * ) FF_GetErrMessage( xFFError ) );
+                FF_PRINTF( "FF_SDDiskInit: FF_CreateIOManager: %s\n", ( const char * ) FF_GetErrMessage( xFFError ) );
                 FF_SDDiskDelete( pxDisk );
                 pxDisk = NULL;
             }

--- a/portable/common/ff_ramdisk.c
+++ b/portable/common/ff_ramdisk.c
@@ -146,7 +146,7 @@ FF_Disk_t * FF_RAMDiskInit( char * pcName,
         xParameters.pvSemaphore = ( void * ) xSemaphoreCreateRecursiveMutex();
         xParameters.xBlockDeviceIsReentrant = pdFALSE;
 
-        pxDisk->pxIOManager = FF_CreateIOManger( &xParameters, &xError );
+        pxDisk->pxIOManager = FF_CreateIOManager( &xParameters, &xError );
 
         if( ( pxDisk->pxIOManager != NULL ) && ( FF_isERR( xError ) == pdFALSE ) )
         {
@@ -181,7 +181,7 @@ FF_Disk_t * FF_RAMDiskInit( char * pcName,
         }
         else
         {
-            FF_PRINTF( "FF_RAMDiskInit: FF_CreateIOManger: %s\n", ( const char * ) FF_GetErrMessage( xError ) );
+            FF_PRINTF( "FF_RAMDiskInit: FF_CreateIOManager: %s\n", ( const char * ) FF_GetErrMessage( xError ) );
 
             /* The disk structure was allocated, but the disk's IO manager could
              * not be allocated, so free the disk again. */

--- a/portable/lpc18xx/ff_sddisk.c
+++ b/portable/lpc18xx/ff_sddisk.c
@@ -233,11 +233,11 @@ FF_Disk_t * FF_SDDiskInit( const char * pcName )
                  * prvFFRead()/prvFFWrite() from different tasks. */
                 xParameters.pvSemaphore = ( void * ) xPlusFATMutex;
 
-                pxDisk->pxIOManager = FF_CreateIOManger( &xParameters, &xFFError );
+                pxDisk->pxIOManager = FF_CreateIOManager( &xParameters, &xFFError );
 
                 if( pxDisk->pxIOManager == NULL )
                 {
-                    FF_PRINTF( "FF_SDDiskInit: FF_CreateIOManger: %s\n", ( const char * ) FF_GetErrMessage( xFFError ) );
+                    FF_PRINTF( "FF_SDDiskInit: FF_CreateIOManager: %s\n", ( const char * ) FF_GetErrMessage( xFFError ) );
                     FF_SDDiskDelete( pxDisk );
                     pxDisk = NULL;
                 }


### PR DESCRIPTION
Fix typo in FF_CreateIOManager

Description
-----------
Fix typo in API

Test Steps
-----------
Cosmetics change, no actual step to reproduce.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Tested on a port for PIC32 that is not part of this porject.
Tested on Linux/POSIX using test/build-combination.

Related Issue
-----------
issue #40 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
