### PR TITLE
Add option to disable FreeRTOS-kernel fetch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,15 @@ else()
     endif()
 endif()
 
+# Optional:  FREERTOS_PLUS_FAT_FETCH_FREERTOS
+#   - when OFF - disable automatic fetch of FreeRTOS-kernel, user must make sure that
+#                target freertos_kernel is available
+#   - When ON  - FreeRTOS-kernel will be fetch using CMake FetchContent_Declare function.
+# Optional:  FREERTOS_PLUS_FAT_FETCH_FREERTOS_GIT_REPO
+# Optional:  FREERTOS_PLUS_FAT_FETCH_FREERTOS_GIT_TAG
+option(FREERTOS_PLUS_FAT_FETCH_FREERTOS "FreeRTOS-Kernel automatic fecth support" ON)
+set(FREERTOS_PLUS_FAT_FETCH_FREERTOS_GIT_REPO "https://github.com/phelter/FreeRTOS-Kernel.git" CACHE STRING "")
+set(FREERTOS_PLUS_FAT_FETCH_FREERTOS_GIT_TAG "feature/fixing-clang-gnu-compiler-warnings" CACHE STRING "")
 
 ########################################################################
 # External Dependencies
@@ -115,12 +124,14 @@ endif()
 #   README.md `Consume with CMake`
 # This will allow you to upgrade submodules and have one common submodule for
 # all your builds despite multiple submodules having different versions.
-include(FetchContent)
+if(FREERTOS_PLUS_FAT_FETCH_FREERTOS)
+  include(FetchContent)
 
-FetchContent_Declare( freertos_kernel
-  GIT_REPOSITORY https://github.com/phelter/FreeRTOS-Kernel.git #https://github.com/FreeRTOS/FreeRTOS-Kernel.git
-  GIT_TAG        feature/fixing-clang-gnu-compiler-warnings #master
-)
+  FetchContent_Declare( freertos_kernel
+    GIT_REPOSITORY ${FREERTOS_PLUS_FAT_FETCH_FREERTOS_GIT_REPO}
+    GIT_TAG        ${FREERTOS_PLUS_FAT_FETCH_FREERTOS_GIT_TAG}
+  )
+endif()
 
 ########################################################################
 add_library( freertos_plus_fat STATIC )
@@ -208,6 +219,6 @@ target_link_libraries( freertos_plus_fat
 add_subdirectory(portable)
 add_subdirectory(test)
 
-
-
-FetchContent_MakeAvailable(freertos_kernel)
+if(FREERTOS_PLUS_FAT_FETCH_FREERTOS)
+  FetchContent_MakeAvailable(freertos_kernel)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,8 +114,8 @@ endif()
 # Optional:  FREERTOS_PLUS_FAT_FETCH_FREERTOS_GIT_REPO
 # Optional:  FREERTOS_PLUS_FAT_FETCH_FREERTOS_GIT_TAG
 option(FREERTOS_PLUS_FAT_FETCH_FREERTOS "FreeRTOS-Kernel automatic fecth support" ON)
-set(FREERTOS_PLUS_FAT_FETCH_FREERTOS_GIT_REPO "https://github.com/phelter/FreeRTOS-Kernel.git" CACHE STRING "")
-set(FREERTOS_PLUS_FAT_FETCH_FREERTOS_GIT_TAG "feature/fixing-clang-gnu-compiler-warnings" CACHE STRING "")
+set(FREERTOS_PLUS_FAT_FETCH_FREERTOS_GIT_REPO "https://github.com/FreeRTOS/FreeRTOS-Kernel.git" CACHE STRING "")
+set(FREERTOS_PLUS_FAT_FETCH_FREERTOS_GIT_TAG "main" CACHE STRING "")
 
 ########################################################################
 # External Dependencies

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ If using CMake, it is recommended to use this repository using FetchContent.
 Add the following into your project's main or a subdirectory's `CMakeLists.txt`:
 
 ```cmake
+include(FetchContent)
+
 FetchContent_Declare( freertos_plus_fat
   GIT_REPOSITORY https://github.com/FreeRTOS/Lab-Project-FreeRTOS-FAT.git
   GIT_TAG        master #Note: Best practice to use specific git-hash or tagged version
@@ -34,6 +36,8 @@ endif()
 
 FetchContent_MakeAvailable(freertos_plus_fat)
 ```
+
+If you already have FreeRTOS in your project, you may skip the fetch content by setting `FREERTOS_PLUS_FAT_FETCH_FREERTOS` to `OFF`.
 
 ### Consuming stand-alone
 It is recommended to use this repository as a submodule. Please refer to [Git Tools — Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules). 


### PR DESCRIPTION
Add option to disable FreeRTOS-kernel fetch

Description
-----------
When using both FreeRTOS-kernel and FreeRTOS-FAT as submodule, it becomes impossible to do something like:

add_subdirectory(submodule/freertos-kernel)
add_subdirectory(submodule/freertos-fat)

This is because FreeRTOS-FAT' CMakeFileLists.txt will try to fetch FreeRTOS-kernel, which already exist.

Add two other option to overwrite default FreeRTOS-kenel git repo and tad.

Some IDE for embedded device do not handle well source code in build directory. 

Test Steps
-----------
Cosmetic change only.

Checklist:
----------
- [X] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Test change with POSIX build, both with FreeRTOS-kernel as submodule and fetchcontent.

Related Issue
-----------
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
