### PR TITLE
Fix dynamic FAT variant detection #55

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,15 @@ jobs:
       - name: Run Uncrustify
         run: |
           uncrustify --version
-          find . -iname "*.[hc]" -exec uncrustify --no-backup --replace --if-changed -c tools/uncrustify.cfg {} +
+          find . -iname "*.[hc]" -exec uncrustify --check -c tools/uncrustify.cfg {} +
           if [ "$?" = "0" ]; then
             exit 0
           else
             echo -e "\033[31;1;43mFormatting check (using Uncrustify) failed...\033[0m"
             echo -e "\033[32;3mTo have the code uncrustified for you, please comment '/bot run uncrustify' (without the quotes) on the Pull Request.\033[0m"
-            git diff --color=always
             exit 1
           fi
       - name: Check For Trailing Whitespace
-        shell: bash
-        if: success() || failure()
         run: |
           set +e
           grep --exclude="README.md" -rnI -e "[[:blank:]]$" .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,18 @@ jobs:
       - name: Run Uncrustify
         run: |
           uncrustify --version
-          find . -iname "*.[hc]" -exec uncrustify --check -c tools/uncrustify.cfg {} +
+          find . -iname "*.[hc]" -exec uncrustify --no-backup --replace --if-changed -c tools/uncrustify.cfg {} +
           if [ "$?" = "0" ]; then
             exit 0
           else
             echo -e "\033[31;1;43mFormatting check (using Uncrustify) failed...\033[0m"
             echo -e "\033[32;3mTo have the code uncrustified for you, please comment '/bot run uncrustify' (without the quotes) on the Pull Request.\033[0m"
+            git diff --color=always
             exit 1
           fi
       - name: Check For Trailing Whitespace
+        shell: bash
+        if: success() || failure()
         run: |
           set +e
           grep --exclude="README.md" -rnI -e "[[:blank:]]$" .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,12 @@ elseif((FREERTOS_PLUS_FAT_PORT STREQUAL "A_CUSTOM_PORT") AND (NOT TARGET freerto
         "       freertos_plus_fat)")
 endif()
 
+# This library requires access to a heap
+# FreeRTOS/FreeRTOS-Kernel previously defaulted to heap4.c
+if(NOT DEFINED FREERTOS_HEAP)
+    message(STATUS "FREERTOS_HEAP not set, setting FREERTOS_HEAP=4")
+    set(FREERTOS_HEAP 4)
+endif()
 
 # Select the appropriate Build Test configuration
 # This is only used when freertos_config is not defined, otherwise the build test will be performed

--- a/ff_ioman.c
+++ b/ff_ioman.c
@@ -767,7 +767,7 @@ static FF_Error_t prvDetermineFatType( FF_IOManager_t * pxIOManager )
                 /* FAT12 */
                 pxPartition->ucType = FF_T_FAT12;
                 #if ( ffconfigFAT_CHECK != 0 )
-                    if( ulEndOfChain == 0x0FF8 )
+                    if( ulEndOfChain != 0x0FF8 )
                     {
                         xError = FF_createERR( FF_ERR_IOMAN_NOT_FAT_FORMATTED, FF_DETERMINEFATTYPE );
                     }
@@ -792,7 +792,7 @@ static FF_Error_t prvDetermineFatType( FF_IOManager_t * pxIOManager )
                     }
                     else
                     {
-                        if( ulEndOfChain != 0x0FF8 )
+                        if( ulEndOfChain == 0x0FF8 )
                         {
                             FF_PRINTF( "Part at %lu is probably a FAT12\n", pxIOManager->xPartition.ulFATBeginLBA );
                         }

--- a/ff_ioman.c
+++ b/ff_ioman.c
@@ -654,7 +654,7 @@ int32_t FF_BlockWrite( FF_IOManager_t * pxIOManager,
     if( ( slRetVal == 0ul ) && ( pxIOManager->xBlkDevice.fnpWriteBlocks != NULL ) )
     {
         do
-        {   /* Make sure we don't execute a NULL. */
+        { /* Make sure we don't execute a NULL. */
             if( ( xSemLocked == pdFALSE ) &&
                 ( ( pxIOManager->ucFlags & FF_IOMAN_BLOCK_DEVICE_IS_REENTRANT ) == pdFALSE ) )
             {
@@ -796,30 +796,30 @@ static FF_Error_t prvDetermineFatType( FF_IOManager_t * pxIOManager )
             /* FAT 16 */
             pxPartition->ucType = FF_T_FAT16;
             #if ( ffconfigFAT_CHECK != 0 )
-            {
-                /* Keep bits 4..15 */
-                ulFirstCluster &= 0xFFF8U;
+                {
+                    /* Keep bits 4..15 */
+                    ulFirstCluster &= 0xFFF8U;
 
-                if( ulFirstCluster == 0xFFF8U )
-                {
-                    /* FAT16 entry OK. */
-                    xError = FF_ERR_NONE;
-                }
-                else
-                {
-                    if( ( ulFirstCluster & 0xFF8U ) == 0xFF8U )
+                    if( ulFirstCluster == 0xFFF8U )
                     {
-                        FF_PRINTF( "FAT_CHECK: FAT16 Part at %lu is probably a FAT12\n", pxIOManager->xPartition.ulFATBeginLBA );
+                        /* FAT16 entry OK. */
+                        xError = FF_ERR_NONE;
                     }
                     else
                     {
-                        FF_PRINTF( "FAT_CHECK: FAT16 Partition has unexpected FAT data %08lX\n",
-                                   ulFirstCluster );
-                    }
+                        if( ( ulFirstCluster & 0xFF8U ) == 0xFF8U )
+                        {
+                            FF_PRINTF( "FAT_CHECK: FAT16 Part at %lu is probably a FAT12\n", pxIOManager->xPartition.ulFATBeginLBA );
+                        }
+                        else
+                        {
+                            FF_PRINTF( "FAT_CHECK: FAT16 Partition has unexpected FAT data %08lX\n",
+                                       ulFirstCluster );
+                        }
 
-                    xError = FF_createERR( FF_ERR_IOMAN_INVALID_FORMAT, FF_DETERMINEFATTYPE );
+                        xError = FF_createERR( FF_ERR_IOMAN_INVALID_FORMAT, FF_DETERMINEFATTYPE );
+                    }
                 }
-            }
             #endif /* ffconfigFAT_CHECK */
         }
         else
@@ -1528,7 +1528,7 @@ FF_Error_t FF_Mount( FF_Disk_t * pxDisk,
         }
 
         if( pxPartition->ulSectorsPerFAT == 0 )
-        {   /* FAT32 */
+        { /* FAT32 */
             pxPartition->ulSectorsPerFAT = FF_getLong( pxBuffer->pucBuffer, FF_FAT_32_SECTORS_PER_FAT );
             pxPartition->ulRootDirCluster = FF_getLong( pxBuffer->pucBuffer, FF_FAT_ROOT_DIR_CLUSTER );
             memcpy( pxPartition->pcVolumeLabel, pxBuffer->pucBuffer + FF_FAT_32_VOL_LABEL, sizeof( pxPartition->pcVolumeLabel ) - 1 );

--- a/ff_ioman.c
+++ b/ff_ioman.c
@@ -654,7 +654,7 @@ int32_t FF_BlockWrite( FF_IOManager_t * pxIOManager,
     if( ( slRetVal == 0ul ) && ( pxIOManager->xBlkDevice.fnpWriteBlocks != NULL ) )
     {
         do
-        { /* Make sure we don't execute a NULL. */
+        {   /* Make sure we don't execute a NULL. */
             if( ( xSemLocked == pdFALSE ) &&
                 ( ( pxIOManager->ucFlags & FF_IOMAN_BLOCK_DEVICE_IS_REENTRANT ) == pdFALSE ) )
             {
@@ -1528,7 +1528,7 @@ FF_Error_t FF_Mount( FF_Disk_t * pxDisk,
         }
 
         if( pxPartition->ulSectorsPerFAT == 0 )
-        { /* FAT32 */
+        {   /* FAT32 */
             pxPartition->ulSectorsPerFAT = FF_getLong( pxBuffer->pucBuffer, FF_FAT_32_SECTORS_PER_FAT );
             pxPartition->ulRootDirCluster = FF_getLong( pxBuffer->pucBuffer, FF_FAT_ROOT_DIR_CLUSTER );
             memcpy( pxPartition->pcVolumeLabel, pxBuffer->pucBuffer + FF_FAT_32_VOL_LABEL, sizeof( pxPartition->pcVolumeLabel ) - 1 );


### PR DESCRIPTION
<!--- Title -->
## Fix dynamic FAT variant detection

### Description
-----------
Only the first two bytes were considered when reading the end-of-chain value from the FAT table. This resulted in FAT32 not being fully detected.
This commit extends the check to the first 4 bytes in the table and makes FAT12 checks more strict while relaxing FAT16 and FAT32 checks since the first 3 bits are ignored but all other valid bits are checked.

### Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Format a valid FAT32 partition (e.g. onto an SD card).
Observe debug output indicating bad partition magic when mounting the partition.
`prvDetermineFatType: firstWord 0x0000FFF8`

### Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
#55 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
