### PR TITLE
Fix usage of FF_createERR macro in prvGetFAT12Entry

### DIFF
--- a/ff_fat.c
+++ b/ff_fat.c
@@ -372,7 +372,7 @@ FF_Buffer_t * prvGetFromFATBuffers( FF_IOManager_t * pxIOManager,
 
         if( FF_isERR( xError ) )
         {
-            xError = FF_CreateError( FF_GETERROR( xError ), FF_GETFATENTRY );
+            xError = FF_createERR( FF_GETERROR( xError ), FF_GETFATENTRY );
         }
         else
         {


### PR DESCRIPTION
Description
-----------
#45 introduced a compilation error about implicit `FF_CreateError` function when using FAT12 support. I assume it was supposed to be `FF_createERR` macro instead so I changed it.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
