### PR TITLE
Enable FAT12 support in CI Build Check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Install Dependencies
+        run: |
+          sudo apt install build-essential cmake ninja-build
       - name: Build checks (Default configuration)
         run: |
-          cmake -S . -B build -DFREERTOS_PLUS_FAT_TEST_CONFIGURATION=DEFAULT_CONF
+          cmake -E env CFLAGS="-DffconfigFAT12_SUPPORT=1" \
+          cmake -S . -B build -DFREERTOS_PLUS_FAT_TEST_CONFIGURATION=DEFAULT_CONF -GNinja
           cmake --build build --target freertos_plus_fat_build_test
 
   # complexity:


### PR DESCRIPTION
Description
-----------
Enable FAT12 support in CI Build Check

Test Steps
-----------
N/A

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ N/A ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
