### PR TITLE
Add missing error check

### DIFF
--- a/ff_file.c
+++ b/ff_file.c
@@ -2447,6 +2447,11 @@ int32_t FF_Write( FF_FILE * pxFile,
                 }
             }
 
+            if( FF_isERR( xError ) )
+            {
+                break;
+            }
+
             /*---------- Write (memcpy) Remaining Bytes */
             if( ulBytesLeft == 0 )
             {


### PR DESCRIPTION
In FF_Write a loop is used to write remaining blocks, and breaks are
used to terminate on error. However, these breaks intended to break the
containing do-while. As they do not, on error from FF_BlockWrite,
control would get passed to after the loop, FF_SetCluster would clear
the error, and FF_WritePartial would be called with ulBytesLeft greater
than block size, which is invalid and causes out of bounds memory
writes.

This is fixed by checking the error after the loop and breaking again.
