### PR TITLE
Add possibility to redefine SD detection pin irq handlers at application level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   # Currently no unit tests
   formatting:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Check Formatting of Files

--- a/include/FreeRTOSFATConfigDefaults.h
+++ b/include/FreeRTOSFATConfigDefaults.h
@@ -521,10 +521,4 @@
     #define FF_CreateIOManger    FF_CreateIOManager
 #endif /* ffconfigENABLE_BACKWARD_COMPATIBILITY */
 
-#ifndef ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER
-
-/* Set to 0 to remove SD detection interrupt handlers definition */
-    #define ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER    1
-#endif
-
 #endif /* ifndef FF_DEFAULTCONFIG_H */

--- a/include/FreeRTOSFATConfigDefaults.h
+++ b/include/FreeRTOSFATConfigDefaults.h
@@ -521,4 +521,10 @@
     #define FF_CreateIOManger    FF_CreateIOManager
 #endif /* ffconfigENABLE_BACKWARD_COMPATIBILITY */
 
+#ifndef ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER
+
+/* Set to 0 to remove SD detection interrupt handlers definition */
+    #define ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER    1
+#endif
+
 #endif /* ifndef FF_DEFAULTCONFIG_H */

--- a/portable/STM32F4xx/ff_sddisk.c
+++ b/portable/STM32F4xx/ff_sddisk.c
@@ -82,6 +82,12 @@
     #define sdARRAY_SIZE( x )    ( int ) ( sizeof( x ) / sizeof( x )[ 0 ] )
 #endif
 
+#ifndef ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER
+    /* Set to 0 to remove SD detection interrupt handlers definition. */
+    #define ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER    1
+#endif
+
+
 /*-----------------------------------------------------------*/
 
 /*

--- a/portable/STM32F4xx/ff_sddisk.c
+++ b/portable/STM32F4xx/ff_sddisk.c
@@ -1153,6 +1153,7 @@ static const char * prvSDCodePrintable( uint32_t ulCode )
 #endif /* SDIO_USES_DMA != 0 */
 /*-----------------------------------------------------------*/
 
+#if ( ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER != 0 )
 void HAL_GPIO_EXTI_Callback( uint16_t GPIO_Pin )
 {
     BaseType_t xHigherPriorityTaskWoken = pdFALSE;
@@ -1163,10 +1164,13 @@ void HAL_GPIO_EXTI_Callback( uint16_t GPIO_Pin )
         portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
     }
 }
+#endif /* ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER != 0*/
 /*-----------------------------------------------------------*/
 
+#if ( ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER != 0 )
 void EXTI15_10_IRQHandler( void )
 {
     HAL_GPIO_EXTI_IRQHandler( configSD_DETECT_PIN ); /* GPIO PIN H.13 */
 }
+#endif /* ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER != 0*/
 /*-----------------------------------------------------------*/

--- a/portable/STM32F4xx/ff_sddisk.c
+++ b/portable/STM32F4xx/ff_sddisk.c
@@ -1160,23 +1160,23 @@ static const char * prvSDCodePrintable( uint32_t ulCode )
 /*-----------------------------------------------------------*/
 
 #if ( ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER != 0 )
-void HAL_GPIO_EXTI_Callback( uint16_t GPIO_Pin )
-{
-    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-
-    if( GPIO_Pin == configSD_DETECT_PIN )
+    void HAL_GPIO_EXTI_Callback( uint16_t GPIO_Pin )
     {
-        vApplicationCardDetectChangeHookFromISR( &xHigherPriorityTaskWoken );
-        portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+        BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+
+        if( GPIO_Pin == configSD_DETECT_PIN )
+        {
+            vApplicationCardDetectChangeHookFromISR( &xHigherPriorityTaskWoken );
+            portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+        }
     }
-}
 #endif /* ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER != 0*/
 /*-----------------------------------------------------------*/
 
 #if ( ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER != 0 )
-void EXTI15_10_IRQHandler( void )
-{
-    HAL_GPIO_EXTI_IRQHandler( configSD_DETECT_PIN ); /* GPIO PIN H.13 */
-}
+    void EXTI15_10_IRQHandler( void )
+    {
+        HAL_GPIO_EXTI_IRQHandler( configSD_DETECT_PIN ); /* GPIO PIN H.13 */
+    }
 #endif /* ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER != 0*/
 /*-----------------------------------------------------------*/

--- a/portable/STM32F7xx/ff_sddisk.c
+++ b/portable/STM32F7xx/ff_sddisk.c
@@ -95,7 +95,6 @@
 #endif
 
 #ifndef ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER
-
     /* Set to 0 to remove SD detection interrupt handlers definition. */
     #define ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER    1
 #endif
@@ -1270,23 +1269,23 @@ static const char * prvSDCodePrintable( uint32_t ulCode )
 /*-----------------------------------------------------------*/
 
 #if ( ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER != 0 )
-void HAL_GPIO_EXTI_Callback( uint16_t GPIO_Pin )
-{
-    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-
-    if( GPIO_Pin == configSD_DETECT_PIN )
+    void HAL_GPIO_EXTI_Callback( uint16_t GPIO_Pin )
     {
-        vApplicationCardDetectChangeHookFromISR( &xHigherPriorityTaskWoken );
-        portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+        BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+
+        if( GPIO_Pin == configSD_DETECT_PIN )
+        {
+            vApplicationCardDetectChangeHookFromISR( &xHigherPriorityTaskWoken );
+            portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+        }
     }
-}
 #endif /* ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER != 0*/
 /*-----------------------------------------------------------*/
 
 #if ( ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER != 0 )
-void EXTI15_10_IRQHandler( void )
-{
-    HAL_GPIO_EXTI_IRQHandler( configSD_DETECT_PIN ); /* GPIO PIN H.13 */
-}
+    void EXTI15_10_IRQHandler( void )
+    {
+        HAL_GPIO_EXTI_IRQHandler( configSD_DETECT_PIN ); /* GPIO PIN H.13 */
+    }
 #endif /* ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER != 0*/
 /*-----------------------------------------------------------*/

--- a/portable/STM32F7xx/ff_sddisk.c
+++ b/portable/STM32F7xx/ff_sddisk.c
@@ -1263,6 +1263,7 @@ static const char * prvSDCodePrintable( uint32_t ulCode )
 #endif /* SDIO_USES_DMA != 0 */
 /*-----------------------------------------------------------*/
 
+#if ( ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER != 0 )
 void HAL_GPIO_EXTI_Callback( uint16_t GPIO_Pin )
 {
     BaseType_t xHigherPriorityTaskWoken = pdFALSE;
@@ -1273,10 +1274,13 @@ void HAL_GPIO_EXTI_Callback( uint16_t GPIO_Pin )
         portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
     }
 }
+#endif /* ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER != 0*/
 /*-----------------------------------------------------------*/
 
+#if ( ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER != 0 )
 void EXTI15_10_IRQHandler( void )
 {
     HAL_GPIO_EXTI_IRQHandler( configSD_DETECT_PIN ); /* GPIO PIN H.13 */
 }
+#endif /* ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER != 0*/
 /*-----------------------------------------------------------*/

--- a/portable/STM32F7xx/ff_sddisk.c
+++ b/portable/STM32F7xx/ff_sddisk.c
@@ -94,6 +94,12 @@
     #define sdARRAY_SIZE( x )    ( int ) ( sizeof( x ) / sizeof( x )[ 0 ] )
 #endif
 
+#ifndef ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER
+
+    /* Set to 0 to remove SD detection interrupt handlers definition. */
+    #define ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER    1
+#endif
+
 #ifdef STM32F7xx
 
     #define SRAM1_MAX_SIZE    ( 368U * 1024U )


### PR DESCRIPTION
<!--- Title -->
Add configuration macro to allow interrupt handlers related to SD detection pin to be deactivated at compile time without changing the source code.

Description
-----------
<!--- Describe your changes in detail. -->
The way STM32F4xx and STM32F7xx ports handle interrupts related to SD detection pin is a bit limiting for 2 reasons:

- the implementation may use a GPIO outside of EXTI10 to 15 range
- the implementation may need GPIOs in EXTI10 to 15 range for other purpose

The idea here is to give the possibility to a user to handle this interrupt - if needed - at application level without changing the library source code. This PR introduces `ffconfigSDIO_DRIVER_DEFINES_SD_DETECTION_INTERRUPT_HANDLER` macro. There is also a modification applied to STM32F4xx and STM32F7xx ports to surround `HAL_GPIO_EXTI_Callback` and `EXTI15_10_IRQHandler` with this newly defined macro.

FYI - related to [this discussion on the forum](https://forums.freertos.org/t/freertos-fat-redefinition-of-irq-handler-in-stm32fx-port/22231/1).

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Integrate the content of this PR in my project to check that functions can be defined at application level without conflicts.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.