### PR TITLE
Fix: Packed attribute missing for FF_Part_t causing buggy memcpy and alignment issues

### DIFF
--- a/include/ff_ioman.h
+++ b/include/ff_ioman.h
@@ -32,6 +32,12 @@
 #ifndef _FF_IOMAN_H_
     #define _FF_IOMAN_H_
 
+#if defined( __GNUC__ )
+    #define FF_PACKED __attribute__( ( packed ) )
+#else
+    #define FF_PACKED
+#endif
+
     #ifdef __cplusplus
     extern "C" {
     #endif
@@ -379,7 +385,7 @@
             ucActive : 8,       /* FF_FAT_PTBL_ACTIVE */
             ucPartitionID : 8,  /* FF_FAT_PTBL_ID */
             bIsExtended : 1;
-    } FF_Part_t;
+    } FF_Part_t FF_PACKED;
 
     typedef struct _SPartFound
     {


### PR DESCRIPTION
Fix: Packed attribute missing for FF_Part_t causing buggy memcpy and alignment issues

Description
-----------
The structure `FF_Part_t` was used with `memcpy` to copy partition data (`pxPartitions + xPartNr` into `p`) in ff_ioman.c, but it contains bitfields:

typedef struct _SPart
{
    uint32_t ulStartLBA;
    uint32_t ulSectorCount;
    uint32_t ucActive : 8,
             ucPartitionID : 8,
             bIsExtended : 1;
} FF_Part_t;

Test Steps
-----------
This is a general fix; no additional tests are required.

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests[NOT TESTED].
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
None opened

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
