### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/portable/CMakeLists.txt
+++ b/portable/CMakeLists.txt
@@ -54,7 +54,7 @@ target_sources( freertos_plus_fat_port
         STM32F4xx/stm32f4xx_hal_sd.h
         STM32F4xx/stm32f4xx_ll_sdmmc.c
         STM32F4xx/stm32f4xx_ll_sdmmc.h>
-    $<$<STREQUAL:${FREERTOS_PLUS_FAT_PORT},STM3F7XX>:
+    $<$<STREQUAL:${FREERTOS_PLUS_FAT_PORT},STM32F7XX>:
         STM32F7xx/ff_sddisk.c
         STM32F7xx/stm32f7xx_hal_sd.c
         STM32F7xx/stm32f7xx_hal_sd.h>


### PR DESCRIPTION
Correct STM3F7xx to STM32F7xx in order to compile correctly

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

The FREERTOS_PLUS_FAT_PORT option was wrong in CMakeList.txt missing a "2" in order to align to other part of code

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Try to compile with option

set(FREERTOS_PLUS_FAT_PORT "STM32F7XX" CACHE STRING "" FORCE)
in originale file and you will have a error becaus you don't compile .c file

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
