### PR TITLE
Use stdioERRNO_THREAD_LOCAL_OFFSET macro for ERRNO setter/getter

### DIFF
--- a/include/ff_stdio.h
+++ b/include/ff_stdio.h
@@ -136,14 +136,14 @@
         /* Cast from a numeric value to a pointer. */
         void * pvValue = ( void * ) ( xErrno );
 
-        vTaskSetThreadLocalStoragePointer( NULL, ffconfigCWD_THREAD_LOCAL_INDEX, pvValue );
+        vTaskSetThreadLocalStoragePointer( NULL, stdioERRNO_THREAD_LOCAL_OFFSET, pvValue );
     }
 
     static portINLINE int stdioGET_ERRNO( void )
     {
         void * pvResult;
 
-        pvResult = pvTaskGetThreadLocalStoragePointer( ( TaskHandle_t ) NULL, ffconfigCWD_THREAD_LOCAL_INDEX );
+        pvResult = pvTaskGetThreadLocalStoragePointer( ( TaskHandle_t ) NULL, stdioERRNO_THREAD_LOCAL_OFFSET );
         /* Cast from a pointer to a number of the same size. */
         intptr_t xErrno = ( intptr_t ) pvResult;
         /* Cast it to an integer. */


### PR DESCRIPTION
Use stdioERRNO_THREAD_LOCAL_OFFSET macro for ERRNO setter/getter

Description
-----------

The previously used ffconfigCWD_THREAD_LOCAL_INDEX has the same value but the stdioERRNO_THREAD_LOCAL_OFFSET macro is more concise.

The compilation will be unchanged as the preprocessor will generate the same output as before.

Test Steps
-----------

No need to test. This is just for more clarity in the codebase and navigation.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
