### PR TITLE
Update modified time when closing written files

### DIFF
--- a/ff_file.c
+++ b/ff_file.c
@@ -2477,6 +2477,11 @@ int32_t FF_Write( FF_FILE * pxFile,
     }
     else
     {
+        if( nBytesWritten > 0U )
+        {
+            pxFile->ulValidFlags |= FF_VALID_FLAG_MODIFIED;
+        }
+
         lResult = ( int32_t ) ( nBytesWritten / ulElementSize );
     }
 
@@ -2550,6 +2555,7 @@ int32_t FF_PutC( FF_FILE * pxFile,
 
             if( FF_isERR( xResult ) == pdFALSE )
             {
+                pxFile->ulValidFlags |= FF_VALID_FLAG_MODIFIED;
                 xResult = ( FF_Error_t ) ucValue;
             }
         } while( pdFALSE );
@@ -3143,16 +3149,37 @@ FF_Error_t FF_Close( FF_FILE * pxFile )
                 xError = FF_GetEntry( pxFile->pxIOManager, pxFile->usDirEntry, pxFile->ulDirCluster, &xOriginalEntry );
 
                 /* Now update the directory entry */
-                if( ( FF_isERR( xError ) == pdFALSE ) &&
-                    ( ( pxFile->ulFileSize != xOriginalEntry.ulFileSize ) || ( pxFile->ulFileSize == 0UL ) ) )
+                if( FF_isERR( xError ) == pdFALSE )
                 {
-                    if( pxFile->ulFileSize == 0UL )
+                    BaseType_t xUpdateDirectoryEntry = pdFALSE;
+
+                    if( ( pxFile->ulFileSize != xOriginalEntry.ulFileSize ) || ( pxFile->ulFileSize == 0UL ) )
                     {
-                        xOriginalEntry.ulObjectCluster = 0;
+                        if( pxFile->ulFileSize == 0UL )
+                        {
+                            xOriginalEntry.ulObjectCluster = 0;
+                        }
+
+                        xOriginalEntry.ulFileSize = pxFile->ulFileSize;
+                        xUpdateDirectoryEntry = pdTRUE;
                     }
 
-                    xOriginalEntry.ulFileSize = pxFile->ulFileSize;
-                    xError = FF_PutEntry( pxFile->pxIOManager, pxFile->usDirEntry, pxFile->ulDirCluster, &xOriginalEntry, NULL );
+                    #if ( ffconfigTIME_SUPPORT != 0 ) && ( ffconfigUPDATE_FILE_MODIFIED_TIME_ON_CLOSE != 0 )
+                    {
+                        if( ( pxFile->ulValidFlags & FF_VALID_FLAG_MODIFIED ) != 0U )
+                        {
+                            /* Reuse this directory-entry write so timestamp
+                             * maintenance does not add another disk update. */
+                            ( void ) FF_GetSystemTime( &xOriginalEntry.xModifiedTime );
+                            xUpdateDirectoryEntry = pdTRUE;
+                        }
+                    }
+                    #endif /* ffconfigTIME_SUPPORT && ffconfigUPDATE_FILE_MODIFIED_TIME_ON_CLOSE */
+
+                    if( xUpdateDirectoryEntry != pdFALSE )
+                    {
+                        xError = FF_PutEntry( pxFile->pxIOManager, pxFile->usDirEntry, pxFile->ulDirCluster, &xOriginalEntry, NULL );
+                    }
                 }
             }
         }
@@ -3230,6 +3257,7 @@ FF_Error_t FF_Close( FF_FILE * pxFile )
 FF_Error_t FF_SetEof( FF_FILE * pxFile )
 {
     FF_Error_t xError;
+    uint32_t ulOriginalFileSize = pxFile->ulFileSize;
 
     /* Check if the file was not deleted and if it was opened with write permissions: */
     if( ( ( pxFile->ulValidFlags & FF_VALID_FLAG_DELETED ) == 0 ) &&
@@ -3244,6 +3272,11 @@ FF_Error_t FF_SetEof( FF_FILE * pxFile )
         else
         {
             xError = FF_ERR_NONE;
+        }
+
+        if( ( FF_isERR( xError ) == pdFALSE ) && ( pxFile->ulFileSize != ulOriginalFileSize ) )
+        {
+            pxFile->ulValidFlags |= FF_VALID_FLAG_MODIFIED;
         }
     }
     else

--- a/ff_file.c
+++ b/ff_file.c
@@ -2465,10 +2465,14 @@ int32_t FF_Write( FF_FILE * pxFile,
                 break;
             }
 
-            FF_WritePartial( pxFile, ulItemLBA, 0, ulBytesLeft, pucBuffer, &xError );
-            nBytesWritten += ulBytesLeft;
+            nBytesWritten += FF_WritePartial( pxFile, ulItemLBA, 0, ulBytesLeft, pucBuffer, &xError );
         }
         while( pdFALSE );
+    }
+
+    if( nBytesWritten > 0U )
+    {
+        pxFile->ulValidFlags |= FF_VALID_FLAG_MODIFIED;
     }
 
     if( FF_isERR( xError ) )
@@ -2477,11 +2481,6 @@ int32_t FF_Write( FF_FILE * pxFile,
     }
     else
     {
-        if( nBytesWritten > 0U )
-        {
-            pxFile->ulValidFlags |= FF_VALID_FLAG_MODIFIED;
-        }
-
         lResult = ( int32_t ) ( nBytesWritten / ulElementSize );
     }
 

--- a/ff_file.c
+++ b/ff_file.c
@@ -1512,12 +1512,15 @@ static FF_Error_t FF_ExtendFile( FF_FILE * pxFile,
 
 static FF_Error_t FF_WriteClusters( FF_FILE * pxFile,
                                     uint32_t ulCount,
-                                    uint8_t * buffer )
+                                    uint8_t * buffer,
+                                    uint32_t * pulClustersWritten )
 {
     uint32_t ulSectors;
     uint32_t ulSequentialClusters = 0;
     uint32_t ulItemLBA;
     FF_Error_t xError = FF_ERR_NONE;
+
+    *pulClustersWritten = 0U;
 
     while( ulCount != 0 )
     {
@@ -1547,6 +1550,7 @@ static FF_Error_t FF_WriteClusters( FF_FILE * pxFile,
             break;
         }
 
+        *pulClustersWritten += ulSequentialClusters + 1U;
         ulCount -= ulSequentialClusters + 1;
 
         FF_LockFAT( pxFile->pxIOManager );
@@ -2376,6 +2380,7 @@ int32_t FF_Write( FF_FILE * pxFile,
             if( ulBytesLeft >= ulBytesPerCluster )
             {
                 uint32_t ulClusters;
+                uint32_t ulClustersWritten;
 
                 FF_SetCluster( pxFile, &xError );
 
@@ -2386,7 +2391,8 @@ int32_t FF_Write( FF_FILE * pxFile,
 
                 ulClusters = ( ulBytesLeft / ulBytesPerCluster );
 
-                xError = FF_WriteClusters( pxFile, ulClusters, pucBuffer );
+                xError = FF_WriteClusters( pxFile, ulClusters, pucBuffer, &ulClustersWritten );
+                nBytesWritten += ulBytesPerCluster * ulClustersWritten;
 
                 if( FF_isERR( xError ) )
                 {
@@ -2396,7 +2402,6 @@ int32_t FF_Write( FF_FILE * pxFile,
                 nBytesToWrite = ulBytesPerCluster * ulClusters;
                 ulBytesLeft -= nBytesToWrite;
                 pucBuffer += nBytesToWrite;
-                nBytesWritten += nBytesToWrite;
                 pxFile->ulFilePointer += nBytesToWrite;
 
                 if( pxFile->ulFilePointer > pxFile->ulFileSize )

--- a/include/FreeRTOSFATConfigDefaults.h
+++ b/include/FreeRTOSFATConfigDefaults.h
@@ -218,6 +218,16 @@
     #define ffconfigTIME_SUPPORT    0
 #endif
 
+#if !defined( ffconfigUPDATE_FILE_MODIFIED_TIME_ON_CLOSE )
+
+/* Set to 1 to update a file's modified timestamp when closing a file that was
+ * changed through FF_Write(), FF_PutC(), or FF_SetEof().
+ *
+ * Set to 0 to preserve the historical behaviour and avoid extra directory
+ * entry writes on close. */
+    #define ffconfigUPDATE_FILE_MODIFIED_TIME_ON_CLOSE    0
+#endif
+
 #if !defined( ffconfigREMOVABLE_MEDIA )
 
 /* Set to 1 if the media is removable (such as a memory card).

--- a/include/ff_file.h
+++ b/include/ff_file.h
@@ -82,6 +82,7 @@ typedef struct _FF_FILE
 #define FF_VALID_FLAG_INVALID     0x00000001U
 #define FF_VALID_FLAG_DELETED     0x00000002U
 #define FF_VALID_FLAG_EXTENDED    0x00000004U
+#define FF_VALID_FLAG_MODIFIED    0x00000008U
 
 /*---------- PROTOTYPES */
 /* PUBLIC (Interfaces): */

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -108,6 +108,69 @@ create_test( ${utest_name}
              "${utest_link_list}"
              "${utest_dep_list}"
              "${test_include_directories}" )
+set( coverage_dep_list ${utest_name} )
+
+set( project_name "ff_file" )
+
+# =====================  Mocks  ================================================
+# Keep the ff_file unit focused on FF_Close().  The module is built with
+# function sections so the linker can discard unrelated file APIs and their
+# dependencies.
+set( mock_list "" )
+list( APPEND mock_list
+      ${MODULE_ROOT_DIR}/include/ff_locking.h
+      ${UNIT_TEST_DIR}/include/ff_dir_mock_subset.h
+      ${MODULE_ROOT_DIR}/include/ff_fat.h
+      ${MODULE_ROOT_DIR}/include/ff_ioman.h
+      ${MODULE_ROOT_DIR}/include/ff_time.h )
+
+set( mock_include_list ${FAT_TEST_INCLUDE_DIRS} )
+set( mock_define_list "" )
+
+# ==================  Module under test  =======================================
+set( real_source_files "" )
+list( APPEND real_source_files
+      ${MODULE_ROOT_DIR}/ff_file.c )
+
+set( real_include_directories ${FAT_TEST_INCLUDE_DIRS} )
+
+# =====================  Test code  ============================================
+set( test_include_directories ${FAT_TEST_INCLUDE_DIRS} )
+
+# ==============================================================================
+set( mock_name "${project_name}_mock" )
+set( real_name "${project_name}_real" )
+
+create_mock_list( ${mock_name}
+                  "${mock_list}"
+                  "${MODULE_ROOT_DIR}/tools/cmock/project.yml"
+                  "${mock_include_list}"
+                  "${mock_define_list}" )
+
+create_real_library( ${real_name}
+                     "${real_source_files}"
+                     "${real_include_directories}"
+                     "${mock_name}" )
+target_compile_options( ${real_name} PRIVATE -ffunction-sections -fdata-sections )
+
+set( utest_dep_list "" )
+list( APPEND utest_dep_list ${real_name} )
+
+set( utest_link_list "" )
+list( APPEND utest_link_list
+      lib${real_name}.a
+      -l${mock_name}
+      -Wl,--gc-sections )
+
+set( utest_name "${project_name}_utest" )
+set( utest_source "${UNIT_TEST_DIR}/ff_file_utest.c" )
+
+create_test( ${utest_name}
+             ${utest_source}
+             "${utest_link_list}"
+             "${utest_dep_list}"
+             "${test_include_directories}" )
+list( APPEND coverage_dep_list ${utest_name} )
 
 # ------------------------------------------------------------------------------
 # `coverage` target: run the tests and collect lcov data into coverage.info.
@@ -115,6 +178,6 @@ create_test( ${utest_name}
 add_custom_target( coverage
     COMMAND ${CMAKE_COMMAND} -DCMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}
             -P ${MODULE_ROOT_DIR}/tools/cmock/coverage.cmake
-    DEPENDS ${utest_name}
+    DEPENDS ${coverage_dep_list}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     COMMENT "Running unit tests and collecting coverage" )

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -113,9 +113,9 @@ set( coverage_dep_list ${utest_name} )
 set( project_name "ff_file" )
 
 # =====================  Mocks  ================================================
-# Keep the ff_file unit focused on FF_Close().  The module is built with
-# function sections so the linker can discard unrelated file APIs and their
-# dependencies.
+# Keep the ff_file unit focused on metadata updates from FF_Write() and
+# FF_Close().  The module is built with function sections so the linker can
+# discard unrelated file APIs and their dependencies.
 set( mock_list "" )
 list( APPEND mock_list
       ${MODULE_ROOT_DIR}/include/ff_locking.h

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -121,7 +121,7 @@ list( APPEND mock_list
       ${MODULE_ROOT_DIR}/include/ff_locking.h
       ${UNIT_TEST_DIR}/include/ff_dir_mock_subset.h
       ${MODULE_ROOT_DIR}/include/ff_fat.h
-      ${MODULE_ROOT_DIR}/include/ff_ioman.h
+      ${UNIT_TEST_DIR}/include/ff_ioman_mock_subset.h
       ${MODULE_ROOT_DIR}/include/ff_time.h )
 
 set( mock_include_list ${FAT_TEST_INCLUDE_DIRS} )

--- a/test/unit-test/config/FreeRTOSFATConfig.h
+++ b/test/unit-test/config/FreeRTOSFATConfig.h
@@ -37,7 +37,10 @@
  * helpers (FF_GetFreeSize / FF_GetVolumeSize) it generates the 64-bit variant.
  * Select the matching 64-bit configuration here so the real declarations agree
  * with the generated mocks. */
-#define ffconfig64_NUM_SUPPORT    ( 1 )
+#define ffconfig64_NUM_SUPPORT                       ( 1 )
+
+#define ffconfigTIME_SUPPORT                         ( 1 )
+#define ffconfigUPDATE_FILE_MODIFIED_TIME_ON_CLOSE    ( 1 )
 
 /* All other ffconfig values fall back to FreeRTOSFATConfigDefaults.h. */
 

--- a/test/unit-test/config/FreeRTOSFATConfig.h
+++ b/test/unit-test/config/FreeRTOSFATConfig.h
@@ -37,9 +37,9 @@
  * helpers (FF_GetFreeSize / FF_GetVolumeSize) it generates the 64-bit variant.
  * Select the matching 64-bit configuration here so the real declarations agree
  * with the generated mocks. */
-#define ffconfig64_NUM_SUPPORT                       ( 1 )
+#define ffconfig64_NUM_SUPPORT                        ( 1 )
 
-#define ffconfigTIME_SUPPORT                         ( 1 )
+#define ffconfigTIME_SUPPORT                          ( 1 )
 #define ffconfigUPDATE_FILE_MODIFIED_TIME_ON_CLOSE    ( 1 )
 
 /* All other ffconfig values fall back to FreeRTOSFATConfigDefaults.h. */

--- a/test/unit-test/ff_file_utest.c
+++ b/test/unit-test/ff_file_utest.c
@@ -109,6 +109,57 @@ void test_FF_Write_marks_file_modified_when_a_later_block_write_fails( void )
     TEST_ASSERT_BITS_HIGH( FF_VALID_FLAG_MODIFIED, xFile.ulValidFlags );
 }
 
+void test_FF_Write_marks_file_modified_when_cluster_write_precedes_traversal_error( void )
+{
+    FF_FILE xFile;
+    uint8_t pucData[ TEST_SECTOR_SIZE * TEST_SECTORS_PER_CLUSTER * 2U ];
+    FF_Error_t xTraverseError = FF_createERR( FF_ERR_IOMAN_DRIVER_FATAL_ERROR, FF_WRITECLUSTERS );
+
+    prvInitFile( &xFile );
+    memset( pucData, 0x5a, sizeof( pucData ) );
+
+    xFile.ulFileSize = sizeof( pucData );
+    xFile.ulObjectCluster = TEST_DATA_CLUSTER;
+    xFile.ulAddrCurrentCluster = TEST_DATA_CLUSTER;
+    xFile.ulChainLength = 3U;
+    xIOManager.xPartition.ucBlkFactor = 1U;
+
+    prvExpectValidHandleCheck();
+    FF_getMinorBlockEntry_ExpectAndReturn( &xIOManager, 0U, 1U, 0U );
+    FF_getClusterChainNumber_ExpectAndReturn( &xIOManager, 0U, 1U, 0U );
+    FF_Cluster2LBA_ExpectAndReturn( &xIOManager, TEST_DATA_CLUSTER, TEST_DATA_LBA );
+    FF_getMajorBlockNumber_ExpectAndReturn( &xIOManager, 0U, 1U, 0U );
+    FF_getMinorBlockNumber_ExpectAndReturn( &xIOManager, 0U, 1U, 0U );
+    FF_getClusterPosition_ExpectAndReturn( &xIOManager, 0U, 1U, 0U );
+    FF_getClusterChainNumber_ExpectAndReturn( &xIOManager, 0U, 1U, 0U );
+    FF_Cluster2LBA_ExpectAndReturn( &xIOManager, TEST_DATA_CLUSTER, TEST_DATA_LBA );
+    FF_getMajorBlockNumber_ExpectAndReturn( &xIOManager, 0U, 1U, 0U );
+    FF_getMinorBlockNumber_ExpectAndReturn( &xIOManager, 0U, 1U, 0U );
+    FF_LockFAT_Expect( &xIOManager );
+    FF_getFATEntry_ExpectAnyArgsAndReturn( TEST_DATA_CLUSTER + 1U );
+    FF_UnlockFAT_Expect( &xIOManager );
+    FF_ReleaseFATBuffers_ExpectAnyArgsAndReturn( FF_ERR_NONE );
+    FF_Cluster2LBA_ExpectAndReturn( &xIOManager, TEST_DATA_CLUSTER, TEST_DATA_LBA );
+    FF_BlockWrite_ExpectAndReturn( &xIOManager,
+                                   TEST_DATA_LBA,
+                                   TEST_SECTORS_PER_CLUSTER * 2U,
+                                   pucData,
+                                   pdFALSE,
+                                   FF_ERR_NONE );
+    FF_LockFAT_Expect( &xIOManager );
+    FF_TraverseFAT_ExpectAndReturn( &xIOManager,
+                                    TEST_DATA_CLUSTER,
+                                    2U,
+                                    NULL,
+                                    TEST_DATA_CLUSTER + 2U );
+    FF_TraverseFAT_IgnoreArg_pxError();
+    FF_TraverseFAT_ReturnThruPtr_pxError( &xTraverseError );
+    FF_UnlockFAT_Expect( &xIOManager );
+
+    TEST_ASSERT_EQUAL( xTraverseError, FF_Write( &xFile, 1U, sizeof( pucData ), pucData ) );
+    TEST_ASSERT_BITS_HIGH( FF_VALID_FLAG_MODIFIED, xFile.ulValidFlags );
+}
+
 void test_FF_Close_updates_modified_time_for_written_file_when_size_is_unchanged( void )
 {
     FF_FILE * pxFile = malloc( sizeof( *pxFile ) );

--- a/test/unit-test/ff_file_utest.c
+++ b/test/unit-test/ff_file_utest.c
@@ -1,0 +1,138 @@
+/*
+ * Unit tests for file-close metadata updates in ff_file.c.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "unity.h"
+
+#include "mock_ff_locking.h"
+#include "mock_ff_dir_mock_subset.h"
+#include "mock_ff_ioman.h"
+#include "mock_ff_time.h"
+
+#include "ff_headers.h"
+
+#define TEST_SECTOR_SIZE            ( 512U )
+#define TEST_SECTORS_PER_CLUSTER    ( 4U )
+#define TEST_DIR_ENTRY              ( 3U )
+#define TEST_DIR_CLUSTER            ( 9U )
+#define TEST_FILE_SIZE              ( 123U )
+#define TEST_UPDATED_YEAR           ( 2026U )
+
+static FF_IOManager_t xIOManager;
+
+static void prvInitFile( FF_FILE * pxFile )
+{
+    memset( &xIOManager, 0, sizeof( xIOManager ) );
+    memset( pxFile, 0, sizeof( *pxFile ) );
+
+    xIOManager.usSectorSize = TEST_SECTOR_SIZE;
+    xIOManager.xPartition.usBlkSize = TEST_SECTOR_SIZE;
+    xIOManager.xPartition.ulSectorsPerCluster = TEST_SECTORS_PER_CLUSTER;
+    xIOManager.FirstFile = pxFile;
+
+    pxFile->pxIOManager = &xIOManager;
+    pxFile->ulFileSize = TEST_FILE_SIZE;
+    pxFile->ucMode = FF_MODE_WRITE;
+    pxFile->usDirEntry = TEST_DIR_ENTRY;
+    pxFile->ulDirCluster = TEST_DIR_CLUSTER;
+}
+
+static void prvExpectValidHandleCheck( void )
+{
+    FF_PendSemaphore_Expect( xIOManager.pvSemaphore );
+    FF_ReleaseSemaphore_Expect( xIOManager.pvSemaphore );
+}
+
+static void prvExpectCloseListRemoval( void )
+{
+    FF_PendSemaphore_Expect( xIOManager.pvSemaphore );
+    FF_ReleaseSemaphore_Expect( xIOManager.pvSemaphore );
+}
+
+void setUp( void )
+{
+}
+
+void tearDown( void )
+{
+}
+
+void test_FF_Close_updates_modified_time_for_written_file_when_size_is_unchanged( void )
+{
+    FF_FILE * pxFile = malloc( sizeof( *pxFile ) );
+    FF_DirEnt_t xEntry;
+    FF_DirEnt_t xExpectedEntry;
+    FF_SystemTime_t xUpdatedTime = { 0 };
+
+    TEST_ASSERT_NOT_NULL( pxFile );
+    prvInitFile( pxFile );
+    pxFile->ulValidFlags = FF_VALID_FLAG_MODIFIED;
+
+    memset( &xEntry, 0, sizeof( xEntry ) );
+    xEntry.ulFileSize = TEST_FILE_SIZE;
+    xEntry.xModifiedTime.Year = 2001U;
+
+    xExpectedEntry = xEntry;
+    xUpdatedTime.Year = TEST_UPDATED_YEAR;
+    xUpdatedTime.Month = 7U;
+    xUpdatedTime.Day = 1U;
+    xUpdatedTime.Hour = 12U;
+    xExpectedEntry.xModifiedTime = xUpdatedTime;
+
+    prvExpectValidHandleCheck();
+    FF_GetEntry_ExpectAndReturn( &xIOManager,
+                                 TEST_DIR_ENTRY,
+                                 TEST_DIR_CLUSTER,
+                                 NULL,
+                                 FF_ERR_NONE );
+    FF_GetEntry_IgnoreArg_pxDirent();
+    FF_GetEntry_ReturnThruPtr_pxDirent( &xEntry );
+    FF_GetSystemTime_ExpectAndReturn( NULL, 0 );
+    FF_GetSystemTime_IgnoreArg_pxTime();
+    FF_GetSystemTime_ReturnThruPtr_pxTime( &xUpdatedTime );
+    FF_PutEntry_ExpectWithArrayAndReturn( &xIOManager,
+                                          1,
+                                          TEST_DIR_ENTRY,
+                                          TEST_DIR_CLUSTER,
+                                          &xExpectedEntry,
+                                          1,
+                                          NULL,
+                                          0,
+                                          FF_ERR_NONE );
+    FF_PutEntry_IgnoreArg_pxIOManager();
+    FF_PutEntry_IgnoreArg_pucContents();
+    prvExpectCloseListRemoval();
+    FF_FlushCache_ExpectAndReturn( &xIOManager, FF_ERR_NONE );
+
+    TEST_ASSERT_EQUAL( FF_ERR_NONE, FF_Close( pxFile ) );
+}
+
+void test_FF_Close_does_not_write_directory_entry_when_file_is_not_modified( void )
+{
+    FF_FILE * pxFile = malloc( sizeof( *pxFile ) );
+    FF_DirEnt_t xEntry;
+
+    TEST_ASSERT_NOT_NULL( pxFile );
+    prvInitFile( pxFile );
+
+    memset( &xEntry, 0, sizeof( xEntry ) );
+    xEntry.ulFileSize = TEST_FILE_SIZE;
+
+    prvExpectValidHandleCheck();
+    FF_GetEntry_ExpectAndReturn( &xIOManager,
+                                 TEST_DIR_ENTRY,
+                                 TEST_DIR_CLUSTER,
+                                 NULL,
+                                 FF_ERR_NONE );
+    FF_GetEntry_IgnoreArg_pxDirent();
+    FF_GetEntry_ReturnThruPtr_pxDirent( &xEntry );
+    prvExpectCloseListRemoval();
+    FF_FlushCache_ExpectAndReturn( &xIOManager, FF_ERR_NONE );
+
+    TEST_ASSERT_EQUAL( FF_ERR_NONE, FF_Close( pxFile ) );
+}

--- a/test/unit-test/ff_file_utest.c
+++ b/test/unit-test/ff_file_utest.c
@@ -11,7 +11,7 @@
 
 #include "mock_ff_locking.h"
 #include "mock_ff_dir_mock_subset.h"
-#include "mock_ff_ioman.h"
+#include "mock_ff_ioman_mock_subset.h"
 #include "mock_ff_time.h"
 
 #include "ff_headers.h"

--- a/test/unit-test/ff_file_utest.c
+++ b/test/unit-test/ff_file_utest.c
@@ -11,6 +11,7 @@
 
 #include "mock_ff_locking.h"
 #include "mock_ff_dir_mock_subset.h"
+#include "mock_ff_fat.h"
 #include "mock_ff_ioman_mock_subset.h"
 #include "mock_ff_time.h"
 
@@ -22,6 +23,8 @@
 #define TEST_DIR_CLUSTER            ( 9U )
 #define TEST_FILE_SIZE              ( 123U )
 #define TEST_UPDATED_YEAR           ( 2026U )
+#define TEST_DATA_CLUSTER           ( 2U )
+#define TEST_DATA_LBA               ( 100U )
 
 static FF_IOManager_t xIOManager;
 
@@ -60,6 +63,50 @@ void setUp( void )
 
 void tearDown( void )
 {
+}
+
+void test_FF_Write_marks_file_modified_when_a_later_block_write_fails( void )
+{
+    FF_FILE xFile;
+    FF_Buffer_t xBuffer;
+    uint8_t pucSector[ TEST_SECTOR_SIZE ];
+    uint8_t pucData[ TEST_SECTOR_SIZE * 2U ];
+    FF_Error_t xWriteError = FF_createERR( FF_ERR_DEVICE_DRIVER_FAILED, FF_WRITE );
+
+    prvInitFile( &xFile );
+    memset( &xBuffer, 0, sizeof( xBuffer ) );
+    memset( pucData, 0x5a, sizeof( pucData ) );
+    xBuffer.pucBuffer = pucSector;
+
+    xIOManager.xPartition.ucBlkFactor = 1U;
+    xFile.ulFilePointer = 1U;
+    xFile.ulFileSize = TEST_SECTOR_SIZE * 2U;
+    xFile.ulObjectCluster = TEST_DATA_CLUSTER;
+    xFile.ulAddrCurrentCluster = TEST_DATA_CLUSTER;
+    xFile.ulChainLength = 1U;
+
+    prvExpectValidHandleCheck();
+    FF_getMinorBlockEntry_ExpectAndReturn( &xIOManager, 1U, 1U, 1U );
+    FF_getClusterChainNumber_ExpectAndReturn( &xIOManager, 1U, 1U, 0U );
+    FF_Cluster2LBA_ExpectAndReturn( &xIOManager, TEST_DATA_CLUSTER, TEST_DATA_LBA );
+    FF_getMajorBlockNumber_ExpectAndReturn( &xIOManager, 1U, 1U, 0U );
+    FF_getMinorBlockNumber_ExpectAndReturn( &xIOManager, 1U, 1U, 0U );
+    FF_GetBuffer_ExpectAndReturn( &xIOManager, TEST_DATA_LBA, FF_MODE_WRITE, &xBuffer );
+    FF_ReleaseBuffer_ExpectAndReturn( &xIOManager, &xBuffer, FF_ERR_NONE );
+    FF_getClusterPosition_ExpectAndReturn( &xIOManager, TEST_SECTOR_SIZE, 1U, TEST_SECTOR_SIZE );
+    FF_getClusterChainNumber_ExpectAndReturn( &xIOManager, TEST_SECTOR_SIZE, 1U, 0U );
+    FF_Cluster2LBA_ExpectAndReturn( &xIOManager, TEST_DATA_CLUSTER, TEST_DATA_LBA );
+    FF_getMajorBlockNumber_ExpectAndReturn( &xIOManager, TEST_SECTOR_SIZE, 1U, 1U );
+    FF_getMinorBlockNumber_ExpectAndReturn( &xIOManager, TEST_SECTOR_SIZE, 1U, 0U );
+    FF_BlockWrite_ExpectAndReturn( &xIOManager,
+                                   TEST_DATA_LBA + 1U,
+                                   1U,
+                                   &pucData[ TEST_SECTOR_SIZE - 1U ],
+                                   pdFALSE,
+                                   xWriteError );
+
+    TEST_ASSERT_EQUAL( xWriteError, FF_Write( &xFile, 1U, sizeof( pucData ), pucData ) );
+    TEST_ASSERT_BITS_HIGH( FF_VALID_FLAG_MODIFIED, xFile.ulValidFlags );
 }
 
 void test_FF_Close_updates_modified_time_for_written_file_when_size_is_unchanged( void )

--- a/test/unit-test/include/ff_dir_mock_subset.h
+++ b/test/unit-test/include/ff_dir_mock_subset.h
@@ -1,0 +1,14 @@
+#ifndef FF_DIR_MOCK_SUBSET_H
+#define FF_DIR_MOCK_SUBSET_H
+
+FF_Error_t FF_GetEntry( FF_IOManager_t * pxIOManager,
+                        uint16_t usEntry,
+                        uint32_t ulDirCluster,
+                        FF_DirEnt_t * pxDirent );
+FF_Error_t FF_PutEntry( FF_IOManager_t * pxIOManager,
+                        uint16_t usEntry,
+                        uint32_t ulDirCluster,
+                        FF_DirEnt_t * pxDirent,
+                        uint8_t * pucContents );
+
+#endif /* FF_DIR_MOCK_SUBSET_H */

--- a/test/unit-test/include/ff_ioman_mock_subset.h
+++ b/test/unit-test/include/ff_ioman_mock_subset.h
@@ -1,0 +1,6 @@
+#ifndef FF_IOMAN_MOCK_SUBSET_H
+#define FF_IOMAN_MOCK_SUBSET_H
+
+FF_Error_t FF_FlushCache( FF_IOManager_t * pxIOManager );
+
+#endif /* FF_IOMAN_MOCK_SUBSET_H */

--- a/test/unit-test/include/ff_ioman_mock_subset.h
+++ b/test/unit-test/include/ff_ioman_mock_subset.h
@@ -2,5 +2,15 @@
 #define FF_IOMAN_MOCK_SUBSET_H
 
 FF_Error_t FF_FlushCache( FF_IOManager_t * pxIOManager );
+int32_t FF_BlockWrite( FF_IOManager_t * pxIOManager,
+                       uint32_t ulSectorLBA,
+                       uint32_t ulNumSectors,
+                       void * pBuffer,
+                       BaseType_t aSemLocked );
+FF_Buffer_t * FF_GetBuffer( FF_IOManager_t * pxIOManager,
+                            uint32_t ulSector,
+                            uint8_t Mode );
+FF_Error_t FF_ReleaseBuffer( FF_IOManager_t * pxIOManager,
+                             FF_Buffer_t * pBuffer );
 
 #endif /* FF_IOMAN_MOCK_SUBSET_H */


### PR DESCRIPTION
Closes #81

## Summary
- Add `ffconfigUPDATE_FILE_MODIFIED_TIME_ON_CLOSE`, defaulting to `0` to preserve existing close-time behavior.
- Track actual file changes with `FF_VALID_FLAG_MODIFIED` after successful writes or EOF truncation, including partial writes and completed cluster writes followed by a later error.
- Reuse the existing `FF_Close()` directory-entry update to refresh `xModifiedTime` when the opt-in config is enabled.
- Keep the `ff_file` metadata tests on narrow mock subsets instead of generating the full `ff_ioman.h` mock surface.

## Testing
- `git diff --check`
- `cmake -S . -B _build/project -G Ninja -DFREERTOS_PLUS_FAT_TEST_CONFIGURATION=DEFAULT_CONF -DFREERTOS_PLUS_FAT_PORT=POSIX`
- `cmake --build _build/project --target freertos_plus_fat_build_test --parallel`
- The four `ff_file` CMock tests pass in a local MinGW harness, including later block-write failure and successful cluster write followed by FAT traversal failure.
- Uncrustify 0.69.0 `--check` passes for `ff_file.c` and `test/unit-test/ff_file_utest.c`.
- The native MinGW CMake unit-test target cannot link CMock's shared mock library because its strict-order globals are defined by the test runner. The local harness links the same generated mocks and runner into one executable; the official unit-test job runs on Ubuntu.

## CI notes
- The previous full CI run passed all six jobs on head `210e6288b5c3fb3fa4b1ec80dc3d8d526851ac80`.
- The workflow for current head `fbde4cf950ff02220b995238f0ae0c2f33e6d43d` is `action_required` with no jobs, so it is waiting for maintainer workflow approval.